### PR TITLE
Stricter Pydantic Validators for Dataset Infos File and Annotation Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ModelCat is currently supported on:
 
 ### Prerequisites
 * `AWS CLI v2`. For more information consult the installation guide: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-* `Python >=3.7` installation (you can use `conda` or virtual environments `venv`)
+* `Python >=3.8` installation (you can use `conda` or virtual environments `venv`)
 * `git` (if you intend to clone ModelCatConnector directly from github)
 
 ### Installing by cloning from GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ dependencies = [ # Optional
   "scandir",
   "pycocotools",
   "requests>=2,<3",
-  "retry"
+  "retry",
+  "pydantic<2"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/sample_datasets/keypoints_sample/annotations/coco_test.json
+++ b/sample_datasets/keypoints_sample/annotations/coco_test.json
@@ -139,7 +139,7 @@
     ],
     "annotations": [
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 30719.3179,
             "iscrowd": 0,
             "keypoints": [
@@ -179,7 +179,7 @@
             "id": 1305
         },
         {
-            "num_keypoints": 17,
+            "num_keypoints": 8,
             "area": 26334.64235,
             "iscrowd": 0,
             "keypoints": [
@@ -219,7 +219,7 @@
             "id": 1448
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 25222.09735,
             "iscrowd": 0,
             "keypoints": [
@@ -259,7 +259,7 @@
             "id": 1267
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 9911.70575,
             "iscrowd": 0,
             "keypoints": [
@@ -299,7 +299,7 @@
             "id": 1345
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 10613.48265,
             "iscrowd": 0,
             "keypoints": [
@@ -339,7 +339,7 @@
             "id": 1456
         },
         {
-            "num_keypoints": 17,
+            "num_keypoints": 8,
             "area": 14975.602,
             "iscrowd": 0,
             "keypoints": [
@@ -379,7 +379,7 @@
             "id": 1437
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 25041.8739,
             "iscrowd": 0,
             "keypoints": [
@@ -419,7 +419,7 @@
             "id": 1283
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 49107.8682,
             "iscrowd": 0,
             "keypoints": [
@@ -459,7 +459,7 @@
             "id": 1260
         },
         {
-            "num_keypoints": 10,
+            "num_keypoints": 8,
             "area": 29424.76855,
             "iscrowd": 0,
             "keypoints": [
@@ -499,7 +499,7 @@
             "id": 1392
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 26332.26015,
             "iscrowd": 0,
             "keypoints": [

--- a/sample_datasets/keypoints_sample/annotations/coco_train.json
+++ b/sample_datasets/keypoints_sample/annotations/coco_train.json
@@ -139,7 +139,7 @@
     ],
     "annotations": [
         {
-            "num_keypoints": 17,
+            "num_keypoints": 8,
             "area": 64755.921,
             "iscrowd": 0,
             "keypoints": [
@@ -179,7 +179,7 @@
             "id": 777
         },
         {
-            "num_keypoints": 17,
+            "num_keypoints": 8,
             "area": 74220.73,
             "iscrowd": 0,
             "keypoints": [
@@ -219,7 +219,7 @@
             "id": 508
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 8004.16745,
             "iscrowd": 0,
             "keypoints": [
@@ -259,7 +259,7 @@
             "id": 896
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 41026.74875,
             "iscrowd": 0,
             "keypoints": [
@@ -299,7 +299,7 @@
             "id": 923
         },
         {
-            "num_keypoints": 14,
+            "num_keypoints": 8,
             "area": 89758.33155,
             "iscrowd": 0,
             "keypoints": [
@@ -339,7 +339,7 @@
             "id": 34
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 9644.57805,
             "iscrowd": 0,
             "keypoints": [
@@ -379,7 +379,7 @@
             "id": 484
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 7954.1565,
             "iscrowd": 0,
             "keypoints": [
@@ -419,7 +419,7 @@
             "id": 86
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 10254.5128,
             "iscrowd": 0,
             "keypoints": [
@@ -459,7 +459,7 @@
             "id": 751
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 24061.24995,
             "iscrowd": 0,
             "keypoints": [
@@ -499,7 +499,7 @@
             "id": 355
         },
         {
-            "num_keypoints": 17,
+            "num_keypoints": 8,
             "area": 20930.9037,
             "iscrowd": 0,
             "keypoints": [

--- a/sample_datasets/keypoints_sample/annotations/coco_validation.json
+++ b/sample_datasets/keypoints_sample/annotations/coco_validation.json
@@ -139,7 +139,7 @@
     ],
     "annotations": [
         {
-            "num_keypoints": 14,
+            "num_keypoints": 8,
             "area": 37963.5776,
             "iscrowd": 0,
             "keypoints": [
@@ -179,7 +179,7 @@
             "id": 1226
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 5980.32645,
             "iscrowd": 0,
             "keypoints": [
@@ -219,7 +219,7 @@
             "id": 1164
         },
         {
-            "num_keypoints": 14,
+            "num_keypoints": 8,
             "area": 12928.56345,
             "iscrowd": 0,
             "keypoints": [
@@ -259,7 +259,7 @@
             "id": 1218
         },
         {
-            "num_keypoints": 13,
+            "num_keypoints": 8,
             "area": 98401.37385,
             "iscrowd": 0,
             "keypoints": [
@@ -299,7 +299,7 @@
             "id": 1171
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 30410.41465,
             "iscrowd": 0,
             "keypoints": [
@@ -339,7 +339,7 @@
             "id": 1149
         },
         {
-            "num_keypoints": 13,
+            "num_keypoints": 8,
             "area": 24990.88785,
             "iscrowd": 0,
             "keypoints": [
@@ -379,7 +379,7 @@
             "id": 1144
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 8599.2729,
             "iscrowd": 0,
             "keypoints": [
@@ -419,7 +419,7 @@
             "id": 1241
         },
         {
-            "num_keypoints": 12,
+            "num_keypoints": 8,
             "area": 80705.9929,
             "iscrowd": 0,
             "keypoints": [
@@ -459,7 +459,7 @@
             "id": 1122
         },
         {
-            "num_keypoints": 16,
+            "num_keypoints": 8,
             "area": 13235.6623,
             "iscrowd": 0,
             "keypoints": [
@@ -499,7 +499,7 @@
             "id": 1238
         },
         {
-            "num_keypoints": 15,
+            "num_keypoints": 8,
             "area": 8953.63335,
             "iscrowd": 0,
             "keypoints": [

--- a/src/modelcat/connector/setup.py
+++ b/src/modelcat/connector/setup.py
@@ -16,7 +16,9 @@ import logging
 from getpass_asterisk.getpass_asterisk import getpass_asterisk as getpass
 
 
-def mask_modelcat_token(token: str, show_prefix: int = 3, show_suffix: int = 3, mask_len: int = 12) -> str:
+def mask_modelcat_token(
+    token: str, show_prefix: int = 3, show_suffix: int = 3, mask_len: int = 12
+) -> str:
     """
     Validate and mask a token of the form: <int>_<40 hex chars>.
     Example output: 1_123********678
@@ -27,7 +29,7 @@ def mask_modelcat_token(token: str, show_prefix: int = 3, show_suffix: int = 3, 
         # Don’t leak invalid input; show a generic masked example length
         return "?:***" + "*" * mask_len + "***"
 
-    group_id, hexpart = m.groups()             # e.g. "1", "123456...40hex..."
+    group_id, hexpart = m.groups()  # e.g. "1", "123456...40hex..."
     head = hexpart[:show_prefix]
     tail = hexpart[-show_suffix:] if show_suffix else ""
     return f"{group_id}_{head}{'*' * mask_len}{tail}"
@@ -71,7 +73,8 @@ def run_setup(verbose: int = 0):
 
     print(
         f"Please enter your {PRODUCT_NAME} credentials (Group ID and OAuth Token)."
-        f"\nYou can obtain them at {PRODUCT_URL}/datasets#upload.\n")
+        f"\nYou can obtain them at {PRODUCT_URL}/datasets#upload.\n"
+    )
     while 1:
         previous_group_clause = f" [{group_id_old}]" if group_id_old is not None else ""
         group_id = input(f"{PRODUCT_NAME} Group ID{previous_group_clause}: ")
@@ -86,10 +89,16 @@ def run_setup(verbose: int = 0):
             )
 
     while 1:
-        previous_token_clause = f" [{mask_modelcat_token(oauth_token_old)}]" if oauth_token_old is not None else ""
+        previous_token_clause = (
+            f" [{mask_modelcat_token(oauth_token_old)}]"
+            if oauth_token_old is not None
+            else ""
+        )
 
         try:
-            oauth_token = getpass(f"{PRODUCT_NAME} OAuth Token{previous_token_clause}: ")
+            oauth_token = getpass(
+                f"{PRODUCT_NAME} OAuth Token{previous_token_clause}: "
+            )
         except EOFError:
             # if user enters an empty string, use the old value
             oauth_token = ""
@@ -144,9 +153,10 @@ def run_setup(verbose: int = 0):
 
 
 def setup_cli():
-
     parser = argparse.ArgumentParser(description="Run ModelCat setup wizard.")
-    parser.add_argument("--debug", default=False, action="store_true", help="Enable debug logging")
+    parser.add_argument(
+        "--debug", default=False, action="store_true", help="Enable debug logging"
+    )
     args = parser.parse_args()
 
     if args.debug:

--- a/src/modelcat/connector/upload.py
+++ b/src/modelcat/connector/upload.py
@@ -14,10 +14,23 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 
-from modelcat.consts import PACKAGE_NAME as ROOT_PACKAGE_NAME, PRODUCT_NAME, PRODUCT_S3_BUCKET, PRODUCT_URL
+from modelcat.consts import (
+    PACKAGE_NAME as ROOT_PACKAGE_NAME,
+    PRODUCT_NAME,
+    PRODUCT_S3_BUCKET,
+    PRODUCT_URL,
+)
 from modelcat.connector.utils.api import APIConfig, ProductAPIClient, APIError
-from modelcat.connector.utils.common import format_local_datetime, UserChoice, resolve_version
-from modelcat.connector.utils.consts import PACKAGE_NAME, DEFAULT_AWS_FORMAT, DEFAULT_AWS_REGION
+from modelcat.connector.utils.common import (
+    format_local_datetime,
+    UserChoice,
+    resolve_version,
+)
+from modelcat.connector.utils.consts import (
+    PACKAGE_NAME,
+    DEFAULT_AWS_FORMAT,
+    DEFAULT_AWS_REGION,
+)
 
 from modelcat.connector.utils.aws import check_aws_configuration, check_s3_access
 
@@ -44,7 +57,7 @@ class DatasetUploader:
 
         if not self.is_valid_uuid(self.group_id):
             print(
-                f'Provided `{PRODUCT_NAME} Group ID` ({self.group_id}) does not have a correct format. '
+                f"Provided `{PRODUCT_NAME} Group ID` ({self.group_id}) does not have a correct format. "
                 'It should be a valid UUID e.g. "461b1b66-8787-11ed-aff3-07f20767316e"'
             )
             exit(1)
@@ -108,7 +121,9 @@ class DatasetUploader:
 
         return True
 
-    def obtain_s3_access(self, api_client: ProductAPIClient, group_id: str, verbose: bool = False):
+    def obtain_s3_access(
+        self, api_client: ProductAPIClient, group_id: str, verbose: bool = False
+    ):
         # get the AWS access key credentials
         print("Obtaining platform access key credentials...")
         try:
@@ -160,7 +175,9 @@ class DatasetUploader:
 
         datasets = api_client.list_datasets()
 
-        datasets_same_name = [ds for ds in datasets if ds.get("name") == self.dataset_name]
+        datasets_same_name = [
+            ds for ds in datasets if ds.get("name") == self.dataset_name
+        ]
         len_same_name = len(datasets_same_name)
         old_ds_uuid = None
         if len_same_name > 0:
@@ -194,8 +211,10 @@ class DatasetUploader:
                 if choice == "o" and len_same_name == 1:
                     choice = "1"
                 else:
-                    print("Multiple datasets with the same name found. Aborting upload.\n"
-                          "Try rerunning in interactive mode to select which dataset to overwrite.")
+                    print(
+                        "Multiple datasets with the same name found. Aborting upload.\n"
+                        "Try rerunning in interactive mode to select which dataset to overwrite."
+                    )
                     exit(1)
                 choice_idx = int(choice) - 1
                 if choice_idx < 0 or choice_idx >= len_same_name:
@@ -223,7 +242,7 @@ class DatasetUploader:
             self.dataset_root,
             self.s3_uri,
             "--exclude",
-            "./.*/**"
+            "./.*/**",
         ]
 
         print("")
@@ -286,8 +305,10 @@ class DatasetUploader:
             )
         except APIError as ae:
             print(f"Dataset registration/upload failed. {PRODUCT_NAME} API error: {ae}")
-            print(f"Please try generating a new OAuth token at {PRODUCT_URL}/datasets#upload "
-                  f"or contact customer support at support@modelcat.ai")
+            print(
+                f"Please try generating a new OAuth token at {PRODUCT_URL}/datasets#upload "
+                f"or contact customer support at support@modelcat.ai"
+            )
             exit(1)
 
     def restore_files(self):
@@ -365,7 +386,7 @@ class DatasetUploader:
 
     @staticmethod
     def normalize_ds_name(name: str):
-        return re.sub("[^a-zA-Z0-9_\.-]", "", name) # noqa W605
+        return re.sub("[^a-zA-Z0-9_\.-]", "", name)  # noqa W605
 
     @staticmethod
     def get_sha(text):
@@ -420,8 +441,8 @@ def upload_cli():
     args = parser.parse_args()
 
     print(
-        f'{PACKAGE_NAME} (v{resolve_version(ROOT_PACKAGE_NAME)}) '
-        f'- dataset validation utility'.center(100)
+        f"{PACKAGE_NAME} (v{resolve_version(ROOT_PACKAGE_NAME)}) "
+        f"- dataset validation utility".center(100)
     )
     print("\n" + "-" * 100)
 

--- a/src/modelcat/connector/utils/__init__.py
+++ b/src/modelcat/connector/utils/__init__.py
@@ -1,3 +1,10 @@
-from .file_sha256 import file_sha256
-from .cli import run_cli_command, CLICommandError
-from .hash_dataset import hash_dataset
+from .file_sha256 import file_sha256 as file_sha256
+from .cli import run_cli_command as run_cli_command, CLICommandError as CLICommandError
+from .hash_dataset import hash_dataset as hash_dataset
+
+__all__ = [
+    "file_sha256",
+    "run_cli_command",
+    "CLICommandError",
+    "hash_dataset",
+]

--- a/src/modelcat/connector/utils/aws.py
+++ b/src/modelcat/connector/utils/aws.py
@@ -11,7 +11,7 @@ def check_awscli() -> bool:
     outputs = []
     try:
         run_cli_command(cmd, line_parser=lambda line: outputs.append(line))
-        log.info(f'awscli version: {" ".join(outputs)}')
+        log.info(f"awscli version: {' '.join(outputs)}")
     except CLICommandError:
         return False
 
@@ -30,9 +30,10 @@ def check_aws_configuration(verbose: int = 0) -> bool:
     return True
 
 
-@retry(exceptions=Exception, delay=20, tries=6, backoff=1, logger=None)  # trying for 6 * 20 = 120 seconds
+@retry(
+    exceptions=Exception, delay=20, tries=6, backoff=1, logger=None
+)  # trying for 6 * 20 = 120 seconds
 def check_s3_access(group_id: str, verbose: bool = False) -> None:
-
     cmd = [
         "aws",
         "s3",

--- a/src/modelcat/connector/utils/hash_dataset.py
+++ b/src/modelcat/connector/utils/hash_dataset.py
@@ -3,5 +3,8 @@ from checksumdir import dirhash
 
 def hash_dataset(dataset_root: str, threads: int = 8, algorithm="sha256"):
     return dirhash(
-        dataset_root, hashfunc=algorithm, excluded_files=["dataset_validator_log.txt"], ignore_hidden=True,
+        dataset_root,
+        hashfunc=algorithm,
+        excluded_files=["dataset_validator_log.txt"],
+        ignore_hidden=True,
     )

--- a/src/modelcat/connector/utils/misc.py
+++ b/src/modelcat/connector/utils/misc.py
@@ -4,11 +4,13 @@ import modelcat.connector as connector
 
 
 def _get_dataset_path() -> str:
-    datasets_folder = 'sample_datasets'
+    datasets_folder = "sample_datasets"
 
     # first try where package is installed
     # this will work for local call of unittests
-    ds_path = osp.abspath(osp.join(osp.dirname(connector.__file__), "..", "..", "..", datasets_folder))
+    ds_path = osp.abspath(
+        osp.join(osp.dirname(connector.__file__), "..", "..", "..", datasets_folder)
+    )
     if osp.exists(ds_path):
         print(ds_path)
         return ds_path
@@ -20,4 +22,4 @@ def _get_dataset_path() -> str:
         print(ds_path)
         return ds_path
 
-    raise FileNotFoundError(f'`{datasets_folder}` cannot be located')
+    raise FileNotFoundError(f"`{datasets_folder}` cannot be located")

--- a/src/modelcat/connector/utils/misc.py
+++ b/src/modelcat/connector/utils/misc.py
@@ -20,4 +20,4 @@ def _get_dataset_path() -> str:
         print(ds_path)
         return ds_path
 
-    raise FileExistsError(f'`{datasets_folder}` cannot be located')
+    raise FileNotFoundError(f'`{datasets_folder}` cannot be located')

--- a/src/modelcat/connector/utils/misc.py
+++ b/src/modelcat/connector/utils/misc.py
@@ -1,0 +1,23 @@
+import os
+import os.path as osp
+import modelcat.connector as connector
+
+
+def _get_dataset_path() -> str:
+    datasets_folder = 'sample_datasets'
+
+    # first try where package is installed
+    # this will work for local call of unittests
+    ds_path = osp.abspath(osp.join(osp.dirname(connector.__file__), "..", "..", "..", datasets_folder))
+    if osp.exists(ds_path):
+        print(ds_path)
+        return ds_path
+
+    # otherwise check current directory (this will work for tox)
+
+    ds_path = osp.abspath(osp.join(os.getcwd(), datasets_folder))
+    if osp.exists(ds_path):
+        print(ds_path)
+        return ds_path
+
+    raise FileExistsError(f'`{datasets_folder}` cannot be located')

--- a/src/modelcat/connector/utils/schemas/annotation.py
+++ b/src/modelcat/connector/utils/schemas/annotation.py
@@ -217,7 +217,7 @@ class Annotation(BaseModel):
         if v is None:
             return []
         
-        # empty bbox is acceptible
+        # empty bbox is acceptable
         if len(v) == 0:
             return v
 

--- a/src/modelcat/connector/utils/schemas/annotation.py
+++ b/src/modelcat/connector/utils/schemas/annotation.py
@@ -152,7 +152,7 @@ class Image(BaseModel):
         flickr_url: Optional Flickr URL (if applicable).
     """
 
-    id: int
+    id: Union[int, float, str]
     file_name: str
     height: Optional[int] = None
     width: Optional[int] = None
@@ -183,8 +183,8 @@ class Annotation(BaseModel):
         num_keypoints: Optional count of visible keypoints (v > 0).
     """
 
-    id: Union[int, str]
-    image_id: Union[int, str]
+    id: Union[int, float, str]
+    image_id: Union[int, float, str]
     category_id: int
     bbox: Optional[List[Union[int, float]]] = Field(default_factory=list)
     segmentation: Optional[List[List[Union[int, float]]]] = None

--- a/src/modelcat/connector/utils/schemas/annotation.py
+++ b/src/modelcat/connector/utils/schemas/annotation.py
@@ -1,0 +1,476 @@
+from typing import Dict, List, Optional, Union
+from pydantic import BaseModel, Field, validator, root_validator
+
+"""
+This file contains validation schemas for COCO-style annotations
+
+Does not do:
+    1. Check path of image files if they exist.
+"""
+
+class Info(BaseModel):
+    """
+    COCO-style dataset 'info' metadata.
+
+    Attributes:
+        year: Dataset year (free-form string, e.g., "2021").
+        version: Dataset version string (e.g., "1.0").
+        description: High-level description of the dataset.
+        contributor: Dataset contributor or organization name.
+        url: URL to the dataset homepage or documentation.
+        date_created: Creation date string (format not enforced).
+
+    All fields are optional and arbitrary extra keys are allowed.
+    """
+    year: Optional[str] = None
+    version: Optional[str] = None
+    description: Optional[str] = None
+    contributor: Optional[str] = None
+    url: Optional[str] = None
+    date_created: Optional[str] = None
+
+    class Config:
+        # any extra field is allowed
+        extra = "allow"
+
+
+class License(BaseModel):
+    """
+    COCO-style license entry describing how images/annotations may be used.
+
+    Attributes:
+        id: Unique integer ID of this license entry.
+        name: Human-readable license name (e.g., "CC-BY-4.0").
+        url: Link to the full license text.
+    """
+    id: int
+    name: Optional[str] = None
+    url: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+        
+
+class Category(BaseModel):
+    """
+    COCO-style category (class) definition.
+
+    Attributes:
+        id: Unique integer category ID (referenced by annotations).
+        name: Category name (e.g., "person", "car").
+        supercategory: Optional broader grouping (e.g., "vehicle").
+        keypoints: Optional ordered list of keypoint labels (for pose tasks).
+            If present, annotations for this category are expected to carry keypoints in x,y,v triplets.
+        skeleton: Optional list of [i, j] **1-based** pairs indicating keypoint connections
+            (used by some tools for visualization). Indices must satisfy 1 <= i,j <= len(keypoints).
+    """
+    
+    id: int
+    name: str
+    supercategory: Optional[str] = None
+    keypoints: Optional[List[str]] = None  # keypoint labels
+    skeleton: Optional[List[List[int]]] = None   # list of [from, to] keypoint connections
+
+    class Config:
+        extra = "allow"
+
+    @validator("keypoints")
+    def _keypoints_when_provided(cls, v):
+        """
+        Validate that 'keypoints'—when present—is a clean list of non-empty strings.
+
+        Returns:
+            The original list if valid, or None if not provided.
+
+        Raises:
+            ValueError: If the provided value is not a list of non-empty strings.
+        """
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            raise ValueError("keypoints must be a list of strings when provided.")
+        if any(not isinstance(k, str) for k in v):
+            raise ValueError("keypoints must be strings.")
+        if any(not k.strip() for k in v):
+            raise ValueError("keypoints entries must be non-empty strings.")
+        return v
+
+    @validator("skeleton")
+    def _skeleton_when_provided(cls, v, values):
+        """
+        Validate that 'skeleton'—when present:
+          - is a list of [i, j] pairs of ints,
+          - uses 1-based indices, and
+          - each index falls within [1, len(keypoints)].
+
+        Raises:
+            ValueError: on bad structure, non-integers, 0/negative indices,
+                out-of-range indices, or if keypoints is missing when skeleton is provided.
+        """
+        if v is None:
+            return v
+        
+        # structural checks
+        if not isinstance(v, list):
+            raise ValueError("skeleton must be a list of [i, j] pairs when provided.")
+        for pair in v:
+            if not (isinstance(pair, list) and len(pair) == 2):
+                raise ValueError("each skeleton entry must be a 2-item list [i, j].")
+            i, j = pair
+            if not (isinstance(i, int) and isinstance(j, int)):
+                raise ValueError("skeleton indices must be integers.")
+            
+        keypoints = values.get("keypoints")
+        num_kp = len(keypoints) if keypoints else None
+
+        # enforce 1-based indexing and range [1, n]
+        for i, j in v:
+            if i < 1 or j < 1:
+                raise ValueError(
+                    f"skeleton indices must be 1-based; got [{i}, {j}] (indices must be >= 1)."
+                )
+            if num_kp is not None and (i > num_kp or j > num_kp):
+                raise ValueError(
+                    f"skeleton indices out of range for {num_kp} keypoints; got [{i}, {j}] (must be <= {num_kp})."
+                )
+        
+        return v
+        
+
+class Image(BaseModel):
+    """
+    COCO-style image metadata entry.
+
+    Attributes:
+        id: Unique integer ID of the image (referenced by annotations).
+        file_name: Image filename (e.g., "/path/to/000000000001.jpg").
+        height: Image height in pixels.
+        width: Image width in pixels.
+        license: Optional integer referencing a License.id.
+        date_captured: Optional capture timestamp string.
+        coco_url: Optional URL to COCO-hosted image (if applicable).
+        flickr_url: Optional Flickr URL (if applicable).
+    """
+
+    id: int
+    file_name: str
+    height: Optional[int] = None
+    width: Optional[int] = None
+    license: Optional[int] = None
+    date_captured: Optional[str] = None
+    coco_url: Optional[str] = None
+    flickr_url: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+        
+        
+class Annotation(BaseModel):
+    """
+    COCO-style annotation for an object instance (and optionally keypoints).
+
+    Attributes:
+        id: Unique integer annotation ID.
+        image_id: Foreign key to Image.id.
+        category_id: Foreign key to Category.id.
+        bbox: Optional [x, y, width, height] with non-negative numbers.
+        segmentation: Optional polygons/masks; here modeled as List[List[float|int]].
+        iscrowd: Optional flag for crowd regions (0 or 1).
+        area: Optional scalar area value.
+        keypoints: Optional flat list for pose tasks:
+                   [x0, y0, v0, x1, y1, v1, ..., xK-1, yK-1, vK-1]
+                   where v must be {0,1,2} is visibility (COCO convention).
+        num_keypoints: Optional count of visible keypoints (v > 0).
+    """
+
+    id: int
+    image_id: int
+    category_id: int
+    bbox: Optional[List[Union[int, float]]] = Field(default_factory=list)
+    segmentation: Optional[List[List[Union[int, float]]]] = None
+    iscrowd: Optional[int] = None  # allow None/0/1
+    area: Optional[Union[int, float]] = None
+
+    # optional keypoints for pose tasks
+    keypoints: Optional[List[Union[int, float]]] = None
+    num_keypoints: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+    @validator("bbox")
+    def _check_bbox(cls, v, values):
+        """
+        Validate 'bbox' when supplied:
+        - If missing or empty: allowed (some tasks omit bbox).
+        - If present: must be [x, y, width, height] with non-negative numerics.
+
+        Returns:
+            The original bbox if valid, or None/[] if not provided.
+
+        Raises:
+            ValueError: If bbox has wrong length/type or negative values.
+        """
+        ann_id = values.get("id", "<unknown>")  # for error messages
+
+        # replace None with [] for uniform downstream handling
+        if v is None:
+            return []
+        
+        # empty bbox is acceptible
+        if len(v) == 0:
+            return v
+
+        # if not empty, must be exactly 4 elements [x, y, width, height]
+        if len(v) != 4:
+            raise ValueError(f"[ann id={ann_id}] bbox must have 4 elements [x, y, width, height] when provided.")
+
+        # validate type and non-negativity
+        x, y, w, h = v
+        for val in (x, y, w, h):
+            if not isinstance(val, (int, float)):
+                raise ValueError(f"[ann id={ann_id}] bbox values must be numeric.")
+            if val < 0:
+                raise ValueError(f"[ann id={ann_id}] bbox values must be non-negative.")
+        return v
+    
+    @validator("keypoints")
+    def _check_keypoints(cls, v, values):
+        ann_id = values.get("id", "<unknown>")  # for error messages
+
+        if v is None:
+            return v
+        if not isinstance(v, list) or (len(v) % 3) != 0:
+            raise ValueError(f"[ann id={ann_id}] keypoints must be a flat list of length 3*K: [x0,y0,v0,...].")
+
+        for i in range(2, len(v), 3):
+            vis = int(v[i])
+            if vis not in (0, 1, 2):
+                raise ValueError(
+                    f"[ann id={ann_id}] keypoints visibility values must be 0,1,2; got {vis} or visibility is missing from keypoints data."
+                    f" keypoints format must be [x0,y0,v0,...]."
+                )
+            x = float(v[i-2])
+            y = float(v[i-1])
+            if vis == 0 and (x != 0 or y != 0):
+                raise ValueError(f"[ann id={ann_id}] When visibility v=0, keypoint coordinates must be (0,0).")
+            if vis > 0 and (x < 0 or y < 0):
+                raise ValueError(f"[ann id={ann_id}] Visible keypoints must have non-negative coordinates.")
+        return v
+
+    @validator("segmentation", pre=True, always=True)
+    def _ensure_seg_default(cls, v):
+        """
+        Ensure 'segmentation' defaults to `[[]]` instead of `None` for consumers
+        that assume the key exists. If provided, pass through unchanged.
+
+        Returns:
+            `[[]]` when `v` is None, else the original value.
+        """
+        return [[]] if v is None else v
+
+    @validator("iscrowd")
+    def _check_iscrowd(cls, v, values):
+        """
+        Validate 'iscrowd' flag when supplied.
+
+        Returns:
+            The original value if valid, or None if not provided.
+
+        Raises:
+            ValueError: If provided and not 0 or 1.
+        """
+        ann_id = values.get("id", "<unknown>")  # for error messages
+        if v is None:
+            return v
+        if not isinstance(v, int) or v not in (0, 1):
+            raise ValueError(f"[ann id={ann_id}] iscrowd must be integer 0 or 1 when provided.")
+        return v
+
+
+def _find_dupes(seq: List[int]) -> List[int]:
+    """
+    Find duplicate integer elements in a sequence.
+
+    Args:
+        seq: A list of integer IDs.
+
+    Returns:
+        A list of the duplicate values (each value appears once, regardless of
+        how many times it was duplicated).
+    """
+    # track values we've seen and collect duplicates.
+    seen = set()
+    dupes = set()
+    for x in seq:
+        if x in seen:
+            dupes.add(x)
+        seen.add(x)
+    return list(dupes)
+
+
+class CocoDataset(BaseModel):
+    """
+    High-level COCO-style dataset container aggregating all components.
+
+    Attributes:
+        info: Optional dataset-level metadata (name, version, etc.).
+        licenses: Optional list of license entries referenced by images.
+        categories: The set of categories/classes available.
+        images: All image metadata entries.
+        annotations: All object (and optional keypoint) annotations.
+
+    Validation performed in the root validator:
+        - Ensures unique IDs within each list (licenses, categories, images, annotations).
+        - Checks that Image.license (if present) refers to a known License.id.
+        - Ensures that Annotation.image_id and Annotation.category_id refer to existing
+          Image.id and Category.id, respectively.
+        - For categories with defined keypoints, enforces that annotations in that category:
+            * Include a 'keypoints' list.
+            * Have a keypoints length equal to (3 * K), where K = len(category.keypoints).
+            * If 'num_keypoints' is provided, it must match the computed count of visible
+              keypoints where visibility v > 0.
+    """
+    info: Optional[Info] = None
+    licenses: Optional[List[License]] = None
+    categories: List[Category]
+    images: List[Image]
+    annotations: List[Annotation]
+
+    class Config:
+        extra = "allow"
+
+
+    @root_validator
+    def _uniqueness_and_refs(cls, values):
+        """
+        Enforce cross-object uniqueness and reference integrity.
+
+        Steps:
+            1) Collect each section (licenses, categories, images, annotations).
+            2) Ensure unique 'id' values within each section.
+            3) Build lookup sets (license_ids, category_ids, image_ids).
+            4) Validate that Image.license (when provided) exists in license_ids.
+            5) Build a per-category expected keypoint count: len(keypoints) or None.
+            6) For each annotation:
+                - image_id must exist in image_ids.
+                - category_id must exist in category_ids.
+                - If the category defines keypoints:
+                    * 'keypoints' must be present on the annotation.
+                    * Its length must be exactly 3 * K.
+                    * If 'num_keypoints' is present, it must equal the number of
+                      visible keypoints (v > 0) computed from the annotation.
+
+        Returns:
+            The original values dict if all checks pass.
+
+        Raises:
+            ValueError: If any integrity rule is violated.
+        """
+        
+        # extract sections, defaulting to empty lists if not available.
+        licenses = values.get("licenses") or []
+        categories = values.get("categories") or []
+        images = values.get("images") or []
+        annotations = values.get("annotations") or []
+
+        # unique IDs within each list
+        def ensure_unique(objs, label):
+            """
+            Helper to assert that each object list has unique 'id' fields.
+
+            Args:
+                objs: A list of Pydantic models each with an 'id' attribute.
+                label: Text label used to format error messages.
+            """
+            ids = [o.id for o in objs]
+            dupes = _find_dupes(ids)
+            if dupes:
+                raise ValueError(f"Duplicate {label} id(s): {sorted(dupes)}")
+
+        # ensure category names are unique (not just ids)
+        cat_names = [c.name for c in categories]
+        if len(set(cat_names)) != len(cat_names):
+            raise ValueError(f"Duplicate category name(s) found: {sorted([n for n in set(cat_names) if cat_names.count(n)>1])}")
+
+        # enforce contiguous ids starting at 1: 1..len(categories)
+        expected_ids = list(range(1, len(categories) + 1))
+        actual_ids = sorted([c.id for c in categories])
+        if actual_ids != expected_ids:
+            raise ValueError(f"Category ids must be contiguous starting at 1; expected {expected_ids}, got {actual_ids}")
+
+        ensure_unique(licenses, "license")
+        ensure_unique(categories, "category")
+        ensure_unique(images, "image")
+        ensure_unique(annotations, "annotation")
+
+        # ID lookup sets for foreign-key checks 
+        license_ids = {l.id for l in licenses}
+        category_ids = {c.id for c in categories}
+        image_ids = {im.id for im in images}
+
+        # validate image -> license references (if any)
+        for im in images:
+            if im.license is not None and im.license not in license_ids:
+                raise ValueError(f"Image id={im.id} references unknown license id={im.license}")
+        
+        # ensure image file_name are non-empty strings and unique
+        file_names = [im.file_name for im in images]
+        if any((not isinstance(fn, str) or not fn.strip()) for fn in file_names):
+            raise ValueError("All images must have a non-empty 'file_name' string.")
+        dupe_fns = [fn for fn in set(file_names) if file_names.count(fn) > 1]
+        if dupe_fns:
+            raise ValueError(f"Duplicate image file_name(s): {sorted(dupe_fns)}")
+
+        # build expected keypoint counts per category
+        # if a category has no keypoints, expected_k is None, otherwise K=len(keypoints).
+        cat_kp_len: Dict[int, Optional[int]] = {}
+        for c in categories:
+            cat_kp_len[c.id] = len(c.keypoints) if c.keypoints else None
+
+        # validate annotations: annotation foreign keys and keypoints rules
+        for ann in annotations:
+            # image_id / category_id must exist
+            if ann.image_id not in image_ids:
+                raise ValueError(f"Annotation id={ann.id} references unknown image_id={ann.image_id}")
+            if ann.category_id not in category_ids:
+                raise ValueError(f"Annotation id={ann.id} references unknown category_id={ann.category_id}")
+
+            # for this annotation, look up how many keypoints are expected given its category
+            expected_k = cat_kp_len.get(ann.category_id)
+    
+            if expected_k:  # keypoints are required for this category
+                if ann.keypoints is None:  # keypoints must be present
+                    raise ValueError(
+                        f"Annotation id={ann.id} (category_id={ann.category_id}) must include 'keypoints'."
+                    )
+                    
+                # annotation must include keypoints with length exactly 3*K.
+                triplets = len(ann.keypoints) // 3
+                if triplets != expected_k:
+                    raise ValueError(
+                        f"Annotation id={ann.id}: keypoints length must be {expected_k*3} "
+                        f"(got {len(ann.keypoints)})."
+                    )
+
+                # validate visibility counts with num_keypoints in annotation
+                # if num_keypoints is given, it must equal visible count (v > 0).
+                if ann.num_keypoints is not None:
+                    # visibility v is every 3rd element starting at index 2: [x, y, v].
+                    visible = sum(1 for i in range(2, len(ann.keypoints), 3) if int(ann.keypoints[i]) > 0)
+                    if ann.num_keypoints != visible:
+                        raise ValueError(
+                            f"Annotation id={ann.id}: num_keypoints={ann.num_keypoints} "
+                            f"but computed visible={visible}."
+                        )
+
+        return values
+    
+
+if __name__ == "__main__":
+    import json
+    annot_path = "/path/to/annotations/coco_train.json"
+    with open(annot_path) as f:
+        data = json.load(f)
+    coco = CocoDataset.parse_obj(data)
+    print(coco)

--- a/src/modelcat/connector/utils/schemas/annotation.py
+++ b/src/modelcat/connector/utils/schemas/annotation.py
@@ -67,7 +67,7 @@ class Category(BaseModel):
     
     id: int
     name: str
-    supercategory: Optional[str] = None
+    supercategory: str
     keypoints: Optional[List[str]] = None  # keypoint labels
     skeleton: Optional[List[List[int]]] = None   # list of [from, to] keypoint connections
 
@@ -183,8 +183,8 @@ class Annotation(BaseModel):
         num_keypoints: Optional count of visible keypoints (v > 0).
     """
 
-    id: int
-    image_id: int
+    id: Union[int, str]
+    image_id: Union[int, str]
     category_id: int
     bbox: Optional[List[Union[int, float]]] = Field(default_factory=list)
     segmentation: Optional[List[List[Union[int, float]]]] = None

--- a/src/modelcat/connector/utils/schemas/datainfo.py
+++ b/src/modelcat/connector/utils/schemas/datainfo.py
@@ -1,0 +1,376 @@
+from typing import Any, Dict, List, Literal, Optional
+from pydantic import BaseModel, Field, validator, root_validator
+
+class ImageFeature(BaseModel):
+    """
+    Declarative descriptor for an image feature in the dataset schema.
+
+    Attributes
+    ----------
+    id : Optional[Any]
+        Optional identifier for the feature. Not used by validators but useful
+        for downstream tooling that wants to track features by an ID.
+    type: Literal["Image"]
+        Discriminator that identifies this feature as an image.
+    """
+    id: Optional[Any] = None
+    type: Literal["Image"] = Field(alias="_type") # because fields starting with an underscore are treated as private attributes by default
+    
+    class Config:
+        allow_population_by_field_name = False  # populate via alias "_type" (default OK)
+
+
+class TextFeature(BaseModel):
+    """
+    Declarative descriptor for a text feature in the dataset schema.
+
+    Attributes
+    ----------
+    id : Optional[Any]
+        Optional identifier for the feature.
+    type : Literal["Text"]
+        Discriminator that identifies this feature as text.
+    """
+    id: Optional[Any] = None
+    type: Literal["Text"] = Field(alias="_type")
+    
+    class Config:
+        allow_population_by_field_name = False
+
+
+class BBoxFeature(BaseModel):
+    """
+    Declarative descriptor for a bounding-box feature in the dataset schema.
+
+    Attributes
+    ----------
+    id : Optional[Any]
+        Optional identifier for the feature.
+    type : Literal["BBoxFeature"]
+        Discriminator that identifies this feature as a bounding-box container.
+        (Actual numeric bbox values live in annotations; this is a *feature type*
+        declaration.)
+    """
+    id: Optional[Any] = None
+    type: Literal["BBoxFeature"] = Field(alias="_type")
+    
+    class Config:
+        allow_population_by_field_name = False
+
+
+class ClassLabel(BaseModel):
+    """
+    Declarative descriptor for a categorical label space.
+
+    Attributes
+    ----------
+    id : Optional[Any]
+        Optional identifier for the feature.
+    num_classes : Optional[int]
+        Number of classes. If provided, should be equal to len(names).
+    names : Optional[List[str]]
+        Ordered list of class names. Index/position usually maps to class id.
+    type : Literal["ClassLabel"]
+        Discriminator for this feature type.
+    """
+    id: Optional[Any] = None
+    num_classes: Optional[int] = None
+    names: Optional[List[str]] = None
+    type: Literal["ClassLabel"] = Field(alias="_type")
+
+    class Config:
+        allow_population_by_field_name = False
+
+    
+class SequenceFeature(BaseModel):
+    """
+    Declarative descriptor for a sequence/array feature, typically used to model
+    a list of objects per image (e.g., detection/keypoint instances).
+
+    Attributes
+    ----------
+    id : Optional[Any]
+        Optional identifier for the feature.
+    _type : Literal["Sequence"]
+        Discriminator indicating this is a sequence container.
+    objects_bbox : Optional[BBoxFeature]
+        If present, declares that each sequence item carries a bbox field.
+    objects_label : Optional[ClassLabel]
+        If present, declares that each sequence item carries a class label.
+    objects_keypoint : Optional["SequenceFeature"]
+        If present, declares that each sequence item carries a *nested sequence*
+        (e.g., per-object keypoints list). Uses a string forward reference to
+        avoid circular typing.
+    """
+    id: Optional[Any] = None
+    type: Literal["Sequence"] = Field(alias="_type")
+    # for per-object attributes: allow nested fields (bbox/label/keypoints)
+    objects_bbox: Optional[BBoxFeature] = None
+    objects_label: Optional[ClassLabel] = None
+    objects_keypoint: Optional["SequenceFeature"] = None
+
+
+class Features(BaseModel):
+    """
+    Top-level feature declaration for the dataset.
+
+    Attributes
+    ----------
+    image : Optional[ImageFeature]
+        Declares the primary image feature (if the dataset is image-based).
+    labels : Optional[SequenceFeature]
+        Declares a sequence of per-image labels/objects (e.g., boxes, classes,
+        keypoints). The internal structure of `labels` determines which fields
+        exist on each object (see `SequenceFeature`).
+    """
+    image: Optional[ImageFeature] = None
+    labels: Optional[SequenceFeature] = None
+    class Config:
+        extra = "allow"
+
+
+class SplitInfo(BaseModel):
+    """
+    Summary statistics for a dataset split (e.g., train/validation/test).
+
+    Attributes
+    ----------
+    name : str
+        Split name (e.g., "train", "validation", "test").
+    dataset_name : str
+        Human-readable or programmatic dataset identifier this split belongs to.
+    num_examples : Optional[int]
+        Number of examples in the split (if known).
+    num_bytes : Optional[int]
+        Total on-disk size of the split (if known), in bytes.
+
+    Config
+    ------
+    extra = "allow"
+        Allows additional split metadata without failing validation.
+    """
+    name: str
+    dataset_name: str
+    num_examples: Optional[int] = None
+    num_bytes: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class TaskTemplate(BaseModel):
+    """
+    Declares the single supervised task this dataset is intended to support.
+
+    Attributes
+    ----------
+    task : Literal["classification", "detection", "keypoints"]
+        Task family. Drives validation expectations for `annotations`.
+    labels : List[str]
+        Ordered list of class names for the task. Position usually maps to id.
+    num_keypoints : Optional[int]
+        Required when `task == "keypoints"`. The total number of keypoints per
+        instance (visible or not).
+    annotations : Optional[List[str]]
+        Names of the fields expected inside an *annotation record* for this task.
+        For example:
+          * classification → {"category_id"}
+          * detection → {"category_id", "bbox"}
+          * keypoints → {"category_id", "bbox", "keypoints"}
+
+    Validators
+    ----------
+    _check_num_keypoints :
+        Ensures `num_keypoints` is present and > 0 when `task == "keypoints"`.
+    _check_annotations_nonempty :
+        If `annotations` is provided, ensures it includes the minimal set of
+        required fields for the declared `task`. (Extra fields are allowed.)
+    """
+    task: Literal["classification", "detection", "keypoints"]
+    labels: List[str]
+    num_keypoints: Optional[int] = None
+    annotations: Optional[List[str]] = None
+
+    @validator("num_keypoints", always=True, pre=True)
+    def _check_num_keypoints(cls, v, values):
+        """
+        Require `num_keypoints` for keypoint tasks and ensure it is a positive integer.
+        Runs even when the field is missing (`always=True`).
+        """
+        if values.get("task") == "keypoints":
+            if not isinstance(v, int) or v <= 0:
+                raise ValueError("For task='keypoints', num_keypoints must be a positive integer.")
+        return v
+
+    @validator("annotations", always=True)
+    def _check_annotations_nonempty(cls, v, values):
+        """
+        If `annotations` is provided, enforce task-specific minimum required fields.
+
+        The validator **does not** forbid additional fields; it only checks that
+        the *required* subset for the chosen task is present.
+        """
+        if v is None:
+            return v
+
+        required_by_task = {
+            "classification": {"category_id"},
+            "detection": {"category_id", "bbox"},
+            "keypoints": {"category_id", "bbox", "keypoints"},
+        }
+        task = values.get("task")
+        if task in required_by_task:
+            missing = required_by_task[task] - set(v)
+            if missing:
+                raise ValueError(
+                    f"For task='{task}', annotations must include {sorted(required_by_task[task])}; "
+                    f"missing: {sorted(missing)}"
+                )
+        return v
+
+    
+class DatasetInfo(BaseModel):
+    """
+    Container for dataset-level metadata, split summaries, and a single task template.
+
+    Attributes
+    ----------
+    task_templates : List[TaskTemplate]
+        A list of task templates. This schema expects *exactly one* template,
+        which is enforced by the `check_min_length` validator.
+    splits : Dict[str, SplitInfo]
+        Mapping of split name → `SplitInfo`. A later root validator ensures
+        that at least "train", "validation", and "test" are present.
+    description : str
+        Human-readable dataset description (optional, defaults to empty string).
+    citation : str
+        Citation information for the dataset (optional).
+    homepage : str
+        Link to the dataset homepage (optional).
+    license : str
+        License string (optional).
+    features : Optional[Features]
+        Declarative feature description (image + object structure).
+    post_processed, supervised_keys, builder_name, config_name, version,
+    download_size, post_processing_size, dataset_size, size_in_bytes :
+        Optional auxiliary metadata fields commonly seen in TFDS-style infos.
+
+    Validators
+    ----------
+    check_min_length :
+        Enforces that exactly one `TaskTemplate` is provided.
+    _require_three_splits :
+        Root validator that checks the presence of the canonical three splits:
+        "train", "validation", and "test". Additional splits may exist.
+
+    Design
+    ------
+    These validators are intentionally conservative: they ensure a minimal set
+    of invariants so that downstream training/evaluation code can make simple
+    assumptions about what exists without defensive checks everywhere.
+    """
+    task_templates: List[TaskTemplate]
+    splits: Dict[str, SplitInfo]
+    description: str = ""
+    citation: str = ""
+    homepage: str = ""
+    license: str = ""
+    features: Optional[Features] = None
+    post_processed: Optional[Any] = None
+    supervised_keys: Optional[Any] = None
+    builder_name: Optional[str] = None
+    config_name: Optional[str] = None
+    version: Optional[Dict] = None
+    download_size: Optional[int] = None
+    post_processing_size: Optional[int] = None
+    dataset_size: Optional[int] = None
+    size_in_bytes: Optional[int] = None
+
+    @validator("task_templates")
+    def check_min_length(cls, v):
+        """
+        Require exactly one task template.
+
+        Rationale
+        ---------
+        Many pipelines assume a single supervised task per dataset/config.
+        If you need multiple templates, consider multiple dataset configs.
+        """
+        if len(v) != 1:
+            raise ValueError("task_templates must contain exactly one element")
+        return v
+
+    @root_validator
+    def _require_three_splits(cls, values):
+        """
+        Ensure canonical split keys exist: "train", "validation", and "test".
+
+        Behavior
+        --------
+        - Fails fast if any of the three are missing.
+        - Permits extra splits (e.g., 'train_small', 'val2017', 'ood_test').
+
+        Notes
+        -----
+        The debug `print` can be useful while wiring up configs and can be
+        removed in production if verbose logs are undesirable.
+        """
+        splits = values.get("splits")
+        
+        if not isinstance(splits, dict) or not splits:
+            raise ValueError("`splits` must be a non-empty mapping with keys: 'train', 'validation', 'test'.")
+    
+        required = ("train", "validation", "test")
+        missing = [k for k in required if k not in splits]
+        if missing:
+            raise ValueError(f"splits must include {required}; missing: {missing}")
+
+        return values
+
+
+class DatasetInfos(BaseModel):
+    """
+    Container for the top-level dataset_infos.json file.
+
+    This model treats the JSON as a mapping:
+        {
+            "<dataset_name>": <DatasetInfo>,
+            "<dataset_name2>": <DatasetInfo>,
+            ...
+        }
+    """
+    __root__: Dict[str, DatasetInfo]
+
+    class Config:
+        extra = "forbid"
+        
+    # make it dict-like
+    def __getitem__(self, key: str) -> DatasetInfo:
+        return self.__root__[key]
+
+    def __iter__(self):
+        return iter(self.__root__)
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def keys(self):
+        return self.__root__.keys()
+
+    def values(self):
+        return self.__root__.values()
+
+    def items(self):
+        return self.__root__.items()
+
+    def get(self, key: str, default=None):
+        return self.__root__.get(key, default)
+
+
+if __name__ == "__main__":
+    import json
+    dataset_infos_path = "/path/to/dataset_infos.json"
+    with open(dataset_infos_path) as f:
+        data = json.load(f)
+    dataset_info = DatasetInfos.parse_obj(data)
+    print(dataset_info)

--- a/src/modelcat/connector/utils/schemas/datainfo.py
+++ b/src/modelcat/connector/utils/schemas/datainfo.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, validator, root_validator
 
+
 class ImageFeature(BaseModel):
     """
     Declarative descriptor for an image feature in the dataset schema.
@@ -13,11 +14,16 @@ class ImageFeature(BaseModel):
     type: Literal["Image"]
         Discriminator that identifies this feature as an image.
     """
+
     id: Optional[Any] = None
-    type: Literal["Image"] = Field(alias="_type") # because fields starting with an underscore are treated as private attributes by default
-    
+    type: Literal["Image"] = Field(
+        alias="_type"
+    )  # because fields starting with an underscore are treated as private attributes by default
+
     class Config:
-        allow_population_by_field_name = False  # populate via alias "_type" (default OK)
+        allow_population_by_field_name = (
+            False  # populate via alias "_type" (default OK)
+        )
 
 
 class TextFeature(BaseModel):
@@ -31,9 +37,10 @@ class TextFeature(BaseModel):
     type : Literal["Text"]
         Discriminator that identifies this feature as text.
     """
+
     id: Optional[Any] = None
     type: Literal["Text"] = Field(alias="_type")
-    
+
     class Config:
         allow_population_by_field_name = False
 
@@ -51,9 +58,10 @@ class BBoxFeature(BaseModel):
         (Actual numeric bbox values live in annotations; this is a *feature type*
         declaration.)
     """
+
     id: Optional[Any] = None
     type: Literal["BBoxFeature"] = Field(alias="_type")
-    
+
     class Config:
         allow_population_by_field_name = False
 
@@ -73,6 +81,7 @@ class ClassLabel(BaseModel):
     type : Literal["ClassLabel"]
         Discriminator for this feature type.
     """
+
     id: Optional[Any] = None
     num_classes: Optional[int] = None
     names: Optional[List[str]] = None
@@ -81,7 +90,7 @@ class ClassLabel(BaseModel):
     class Config:
         allow_population_by_field_name = False
 
-    
+
 class SequenceFeature(BaseModel):
     """
     Declarative descriptor for a sequence/array feature, typically used to model
@@ -102,6 +111,7 @@ class SequenceFeature(BaseModel):
         (e.g., per-object keypoints list). Uses a string forward reference to
         avoid circular typing.
     """
+
     id: Optional[Any] = None
     type: Literal["Sequence"] = Field(alias="_type")
     # for per-object attributes: allow nested fields (bbox/label/keypoints)
@@ -123,8 +133,10 @@ class Features(BaseModel):
         keypoints). The internal structure of `labels` determines which fields
         exist on each object (see `SequenceFeature`).
     """
+
     image: Optional[ImageFeature] = None
     labels: Optional[SequenceFeature] = None
+
     class Config:
         extra = "allow"
 
@@ -149,6 +161,7 @@ class SplitInfo(BaseModel):
     extra = "allow"
         Allows additional split metadata without failing validation.
     """
+
     name: str
     dataset_name: str
     num_examples: Optional[int] = None
@@ -186,6 +199,7 @@ class TaskTemplate(BaseModel):
         If `annotations` is provided, ensures it includes the minimal set of
         required fields for the declared `task`. (Extra fields are allowed.)
     """
+
     task: Literal["classification", "detection", "keypoints"]
     labels: List[str]
     num_keypoints: Optional[int] = None
@@ -199,7 +213,9 @@ class TaskTemplate(BaseModel):
         """
         if values.get("task") == "keypoints":
             if not isinstance(v, int) or v <= 0:
-                raise ValueError("For task='keypoints', num_keypoints must be a positive integer.")
+                raise ValueError(
+                    "For task='keypoints', num_keypoints must be a positive integer."
+                )
         return v
 
     @validator("annotations", always=True)
@@ -228,7 +244,7 @@ class TaskTemplate(BaseModel):
                 )
         return v
 
-    
+
 class DatasetInfo(BaseModel):
     """
     Container for dataset-level metadata, split summaries, and a single task template.
@@ -269,6 +285,7 @@ class DatasetInfo(BaseModel):
     of invariants so that downstream training/evaluation code can make simple
     assumptions about what exists without defensive checks everywhere.
     """
+
     task_templates: List[TaskTemplate]
     splits: Dict[str, SplitInfo]
     description: str = ""
@@ -316,10 +333,12 @@ class DatasetInfo(BaseModel):
         removed in production if verbose logs are undesirable.
         """
         splits = values.get("splits")
-        
+
         if not isinstance(splits, dict) or not splits:
-            raise ValueError("`splits` must be a non-empty mapping with keys: 'train', 'validation', 'test'.")
-    
+            raise ValueError(
+                "`splits` must be a non-empty mapping with keys: 'train', 'validation', 'test'."
+            )
+
         required = ("train", "validation", "test")
         missing = [k for k in required if k not in splits]
         if missing:
@@ -339,11 +358,12 @@ class DatasetInfos(BaseModel):
             ...
         }
     """
+
     __root__: Dict[str, DatasetInfo]
 
     class Config:
         extra = "forbid"
-        
+
     # make it dict-like
     def __getitem__(self, key: str) -> DatasetInfo:
         return self.__root__[key]
@@ -369,6 +389,7 @@ class DatasetInfos(BaseModel):
 
 if __name__ == "__main__":
     import json
+
     dataset_infos_path = "/path/to/dataset_infos.json"
     with open(dataset_infos_path) as f:
         data = json.load(f)

--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -12,7 +12,8 @@ import shutil
 from .utils import hash_dataset
 import importlib.metadata
 from pycocotools.coco import COCO
-
+from .utils.schemas.datainfo import DatasetInfo
+from .utils.schemas.annotation import CocoDataset
 
 class DatasetValidator:
 
@@ -349,6 +350,17 @@ class DatasetValidator:
                     f"Auto-fix: added size_in_bytes {dataset_info['size_in_bytes']} to dataset_infos.json."
                 )
 
+        # run pydantic validation
+        try:
+            DatasetInfo.parse_obj(dataset_info)
+        except Exception as e:
+            messages.append(
+                {
+                    "type": "error",
+                    "message": f'"dataset_infos.json" file validation error: {e}',
+                }
+            )
+        
         return messages, ann_file_names, split_names, label_names
 
     def validate_annotations_and_images(
@@ -571,6 +583,17 @@ class DatasetValidator:
                 {
                     "type": "error",
                     "message": f'The annotation file "{coco_file_name}" is not formatted correctly: {e}.',
+                }
+            )
+            
+        # run pydantic validation
+        try:
+            CocoDataset.parse_obj(coco)
+        except Exception as e:
+            messages.append(
+                {
+                    "type": "error",
+                    "message": f'"{coco_file_path}" file validation error: {e}',
                 }
             )
 

--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -20,24 +20,22 @@ from modelcat.connector.utils.common import UserChoice
 
 
 class DatasetValidator:
-
     def __init__(
-            self,
-            dataset_root_dir: str,
-            working_dir: str = None,
-            auto_fix: bool = False,
-            auto_fix_2: UserChoice = UserChoice.NO,
+        self,
+        dataset_root_dir: str,
+        working_dir: str = None,
+        auto_fix: bool = False,
+        auto_fix_2: UserChoice = UserChoice.NO,
     ):
-
         if not osp.exists(dataset_root_dir):
             print(f"Path does not exists: {dataset_root_dir}")
             exit(1)
 
         self.root_dir = dataset_root_dir
-        self.image_dir = os.path.join(self.root_dir, 'images')
-        self.ann_dir = os.path.join(self.root_dir, 'annotations')
+        self.image_dir = os.path.join(self.root_dir, "images")
+        self.ann_dir = os.path.join(self.root_dir, "annotations")
         self.working_dir = working_dir
-        self.backup_dir = os.path.join(self.working_dir, '.backup')
+        self.backup_dir = os.path.join(self.working_dir, ".backup")
         self.auto_fix = auto_fix
         self.log_filename = "dataset_validator_log.txt"
         self.auto_fix_2 = auto_fix_2
@@ -111,15 +109,19 @@ class DatasetValidator:
             if first_image is not None:
                 # No need to backup here as we're creating a new file, not modifying an existing one
                 shutil.copy(first_image, thumbnail_path)
-                log.debug(f"Auto-fix: thumbnail generated automatically from image '{first_image}'")
+                log.debug(
+                    f"Auto-fix: thumbnail generated automatically from image '{first_image}'"
+                )
             else:
-                self.messages.append({
-                    'type': 'error',
-                    'message': 'Couldn\'t find any image to serve as a thumbnail for the dataset.'
-                })
+                self.messages.append(
+                    {
+                        "type": "error",
+                        "message": "Couldn't find any image to serve as a thumbnail for the dataset.",
+                    }
+                )
 
-        dataset_info_messages, ann_file_names, split_names, label_names = self.validate_dataset_infos_file(
-            dataset_infos_path
+        dataset_info_messages, ann_file_names, split_names, label_names = (
+            self.validate_dataset_infos_file(dataset_infos_path)
         )
         self.messages += dataset_info_messages
 
@@ -132,16 +134,13 @@ class DatasetValidator:
 
         self.messages += annotations_messages
 
-        split_size_messages = self.validate_split_sizes(
-            dataset_infos_path, split_names
-        )
+        split_size_messages = self.validate_split_sizes(dataset_infos_path, split_names)
 
         self.messages += split_size_messages
 
         return self.messages, self.restart_analysis
 
     def validate_dataset_infos_file(self, dataset_infos_path: str):
-
         messages = []
         ann_file_names = []
         split_names = []
@@ -199,7 +198,9 @@ class DatasetValidator:
                     )
                 else:
                     dataset_info[key] = ""
-                    log.debug(f"Auto-fix: '{key}' key added to 'dataset_infos.json' file")
+                    log.debug(
+                        f"Auto-fix: '{key}' key added to 'dataset_infos.json' file"
+                    )
 
         if "splits" in dataset_info:
             for split in ["train", "test", "validation"]:
@@ -208,7 +209,7 @@ class DatasetValidator:
                         {
                             "type": "error",
                             "message": f'Split "{split}" is missing in the splits listed in the '
-                                       f'"dataset_infos.json" file.',
+                            f'"dataset_infos.json" file.',
                         }
                     )
                 else:
@@ -217,7 +218,7 @@ class DatasetValidator:
                             {
                                 "type": "error",
                                 "message": f'Split "{split}" is missing the "dataset_name" key in the '
-                                           f'"dataset_infos.json" file.',
+                                f'"dataset_infos.json" file.',
                             }
                         )
 
@@ -248,8 +249,8 @@ class DatasetValidator:
                             {
                                 "type": "error",
                                 "message": f'Found unexpected value of "{task_template["task"]}" '
-                                           f'in the "task_templates/task" field inside the "dataset_infos.json" file. '
-                                           f'Expected either "classification", "detection" or "keypoints".',
+                                f'in the "task_templates/task" field inside the "dataset_infos.json" file. '
+                                f'Expected either "classification", "detection" or "keypoints".',
                             }
                         )
                 if "labels" not in task_template:
@@ -277,73 +278,103 @@ class DatasetValidator:
                     if not self.auto_fix:
                         messages.append(
                             {
-                                'type': 'warning',
-                                'message': f'"dataset_infos.json" shows {dataset_info["dataset_size"]} images in '
-                                           f'dataset, but {real_img_count} were found in the "images" directory.'
+                                "type": "warning",
+                                "message": f'"dataset_infos.json" shows {dataset_info["dataset_size"]} images in '
+                                f'dataset, but {real_img_count} were found in the "images" directory.',
                             }
                         )
                     else:
-                        dataset_infos_json[dataset_name]["dataset_size"] = real_img_count
-                        self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                        log.debug(f"Auto-fix: changed dataset_size to {real_img_count}.")
+                        dataset_infos_json[dataset_name]["dataset_size"] = (
+                            real_img_count
+                        )
+                        self.reload_dataset_infos(
+                            dataset_infos_path, dataset_infos_json
+                        )
+                        log.debug(
+                            f"Auto-fix: changed dataset_size to {real_img_count}."
+                        )
             else:
                 if not self.auto_fix:
                     messages.append(
                         {
-                            'type': 'warning',
-                            'message': f'"dataset_infos.json" doesn\'t contain a valid entry for '
-                                       f'"dataset_size", {real_img_count} were found in the "images" '
-                                       f'directory.'
+                            "type": "warning",
+                            "message": f'"dataset_infos.json" doesn\'t contain a valid entry for '
+                            f'"dataset_size", {real_img_count} were found in the "images" '
+                            f"directory.",
                         }
                     )
                 else:
                     dataset_infos_json[dataset_name]["dataset_size"] = real_img_count
                     self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                    log.debug(f"Auto-fix: added dataset_size ({real_img_count} to dataset_infos.json")
+                    log.debug(
+                        f"Auto-fix: added dataset_size ({real_img_count} to dataset_infos.json"
+                    )
         else:
             if not self.auto_fix:
                 messages.append(
                     {
-                        'type': 'warning',
-                        'message': '"dataset_infos.json" doesn\'t contain an entry for "dataset_size".'
+                        "type": "warning",
+                        "message": '"dataset_infos.json" doesn\'t contain an entry for "dataset_size".',
                     }
                 )
             else:
                 dataset_infos_json[dataset_name]["dataset_size"] = real_img_count
                 self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                log.debug(f"Auto-fix: added dataset_size ({real_img_count} to dataset_infos.json.")
-        real_size_in_bytes = _calculate_coco_dataset_size(self.image_dir, self.ann_dir, ann_file_names)
+                log.debug(
+                    f"Auto-fix: added dataset_size ({real_img_count} to dataset_infos.json."
+                )
+        real_size_in_bytes = _calculate_coco_dataset_size(
+            self.image_dir, self.ann_dir, ann_file_names
+        )
 
         # currently supporting dataset sizes up to 100 GB
         if real_size_in_bytes > MAX_DATASET_SIZE:
             messages.append(
                 {
-                    'type': 'error',
-                    'message': f'The size of the dataset is {real_size_in_bytes / 100e9:.2f} GB, which is larger than '
-                               f'the maximum allowed size of {MAX_DATASET_SIZE_STR}. \nNotify customer support at '
-                               f'support@modelcat.ai for support of datasets larger than {MAX_DATASET_SIZE_STR}.'
+                    "type": "error",
+                    "message": f"The size of the dataset is {real_size_in_bytes / 100e9:.2f} GB, which is larger than "
+                    f"the maximum allowed size of {MAX_DATASET_SIZE_STR}. \nNotify customer support at "
+                    f"support@modelcat.ai for support of datasets larger than {MAX_DATASET_SIZE_STR}.",
                 }
             )
         if "size_in_bytes" in dataset_info:
             if type(dataset_info["size_in_bytes"]) is int:
-                if not math.isclose(real_size_in_bytes, dataset_info["size_in_bytes"], rel_tol=0.001):
+                if not math.isclose(
+                    real_size_in_bytes, dataset_info["size_in_bytes"], rel_tol=0.001
+                ):
                     if not self.auto_fix:
-                        messages.append({'type': 'warning',
-                                         'message': f'"dataset_infos.json" shows {dataset_info["size_in_bytes"]}B as '
-                                                    f'dataset size, but {real_size_in_bytes} B size was calculated '
-                                                    f'using the dataset root directory.'})
+                        messages.append(
+                            {
+                                "type": "warning",
+                                "message": f'"dataset_infos.json" shows {dataset_info["size_in_bytes"]}B as '
+                                f"dataset size, but {real_size_in_bytes} B size was calculated "
+                                f"using the dataset root directory.",
+                            }
+                        )
                     else:
-                        dataset_infos_json[dataset_name]["size_in_bytes"] = real_size_in_bytes
-                        self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                        log.debug(f"Auto-fix: changed size_in_bytes to {real_size_in_bytes}.")
+                        dataset_infos_json[dataset_name]["size_in_bytes"] = (
+                            real_size_in_bytes
+                        )
+                        self.reload_dataset_infos(
+                            dataset_infos_path, dataset_infos_json
+                        )
+                        log.debug(
+                            f"Auto-fix: changed size_in_bytes to {real_size_in_bytes}."
+                        )
             else:
                 if not self.auto_fix:
-                    messages.append({'type': 'warning',
-                                     'message': f'"dataset_infos.json" doesn\'t contain a valid entry for '
-                                                f'"size_in_bytes", {real_size_in_bytes} B size was calculated using '
-                                                f'the dataset root directory.'})
+                    messages.append(
+                        {
+                            "type": "warning",
+                            "message": f'"dataset_infos.json" doesn\'t contain a valid entry for '
+                            f'"size_in_bytes", {real_size_in_bytes} B size was calculated using '
+                            f"the dataset root directory.",
+                        }
+                    )
                 else:
-                    dataset_infos_json[dataset_name]["size_in_bytes"] = real_size_in_bytes
+                    dataset_infos_json[dataset_name]["size_in_bytes"] = (
+                        real_size_in_bytes
+                    )
                     self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
                     log.debug(
                         f"Auto-fix: added size_in_bytes {dataset_info['size_in_bytes']} to dataset_infos.json."
@@ -352,8 +383,8 @@ class DatasetValidator:
             if not self.auto_fix:
                 messages.append(
                     {
-                        'type': 'warning',
-                        'message': '"dataset_infos.json" doesn\'t contain an entry for "size_in_bytes".'
+                        "type": "warning",
+                        "message": '"dataset_infos.json" doesn\'t contain an entry for "size_in_bytes".',
                     }
                 )
             else:
@@ -373,15 +404,15 @@ class DatasetValidator:
                     "message": f'"dataset_infos.json" file validation error: {e}',
                 }
             )
-        
+
         return messages, ann_file_names, split_names, label_names
 
     def validate_annotations_and_images(
-            self,
-            annotations_required: bool,
-            ann_file_names: List[str],
-            split_names: List[str],
-            label_names: List[str],
+        self,
+        annotations_required: bool,
+        ann_file_names: List[str],
+        split_names: List[str],
+        label_names: List[str],
     ):
         messages = []
 
@@ -407,21 +438,25 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{ann_file}" listed in "dataset_infos.json" is missing in '
-                                   f'the "annotations" folder.',
+                        f'the "annotations" folder.',
                     }
                 )
             else:
-                messages += self.validate_coco_file(osp.join(self.ann_dir, ann_file), label_names)
+                messages += self.validate_coco_file(
+                    osp.join(self.ann_dir, ann_file), label_names
+                )
 
         for ann_file in ann_file_names:
-            messages += self.check_for_duplicate_images(osp.join(self.ann_dir, ann_file))
+            messages += self.check_for_duplicate_images(
+                osp.join(self.ann_dir, ann_file)
+            )
         for ann_file in ann_file_names:
             messages += self.check_split_image_duplicates(
                 osp.join(self.ann_dir, ann_file)
             )
 
         for (i1, ann_file_1), (i2, ann_file_2) in combinations(
-                enumerate(ann_file_names), 2
+            enumerate(ann_file_names), 2
         ):
             messages += self.check_for_split_leakage(
                 osp.join(self.ann_dir, ann_file_1),
@@ -431,9 +466,7 @@ class DatasetValidator:
             )
         return messages
 
-    def validate_coco_file(
-            self, coco_file_path: str, label_names: List[str]
-    ):
+    def validate_coco_file(self, coco_file_path: str, label_names: List[str]):
         messages = []
         coco_file_name = osp.basename(coco_file_path)
 
@@ -459,7 +492,7 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The category names in the annotation file "{coco_file_name}" do not match the '
-                                   f'label names in the "dataset_infos.json" file.',
+                        f'label names in the "dataset_infos.json" file.',
                     }
                 )
 
@@ -481,7 +514,7 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains {len(missing_images)} images '
-                                   f'that are not found in the "images" folder.',
+                        f'that are not found in the "images" folder.',
                     }
                 )
                 if self.log_filepath is not None:
@@ -498,8 +531,8 @@ class DatasetValidator:
 
             if len(imgs_without_anns) > 0:
                 if self.handle_permission(
-                        f'Auto-fix: remove all images without annotations from the "{coco_file_name}" annotation '
-                        f'file? (y/n):'
+                    f'Auto-fix: remove all images without annotations from the "{coco_file_name}" annotation '
+                    f"file? (y/n):"
                 ):
                     for img_filename in imgs_without_anns:
                         img_path = osp.join(self.image_dir, img_filename)
@@ -507,34 +540,46 @@ class DatasetValidator:
                             # Backup the file before removing it
                             self.backup_file(img_path)
                             os.remove(img_path)
-                    coco["images"] = [image for image in coco["images"] if
-                                      image["file_name"] not in imgs_without_anns]
+                    coco["images"] = [
+                        image
+                        for image in coco["images"]
+                        if image["file_name"] not in imgs_without_anns
+                    ]
                     self.reload_coco(coco_file_path, coco)
                     imgs_without_anns = [
-                        img["file_name"] for img in coco["images"] if not any(ann["image_id"] == img["id"]
-                                                                              for ann in coco["annotations"])]
+                        img["file_name"]
+                        for img in coco["images"]
+                        if not any(
+                            ann["image_id"] == img["id"] for ann in coco["annotations"]
+                        )
+                    ]
                     if len(imgs_without_anns) > 0:
-                        raise Exception("Auto-fix: failure. Failed to remove imgs without anns from the coco file.")
+                        raise Exception(
+                            "Auto-fix: failure. Failed to remove imgs without anns from the coco file."
+                        )
                     log.debug("Auto-fix: removed all images without annotations.")
                     # since images were deleted, the validation needs to run again for dataset_size and size_in_bytes
                     self.restart_analysis = True
                 else:
                     messages.append(
                         {
-                            'type': 'warning',
-                            'message': f'The annotation file "{coco_file_name}" contains {len(imgs_without_anns)} '
-                                       f'images that don\'t have corresponding annotations.'
+                            "type": "warning",
+                            "message": f'The annotation file "{coco_file_name}" contains {len(imgs_without_anns)} '
+                            f"images that don't have corresponding annotations.",
                         }
                     )
                     if self.log_filepath is not None:
                         try:
-                            with open(self.log_filepath, 'a') as file:
+                            with open(self.log_filepath, "a") as file:
                                 for img in imgs_without_anns:
                                     file.write(
                                         f'Image "{img}" from the "{coco_file_name}" annotation file doesn\'t have any '
-                                        f'annotations.\n')
+                                        f"annotations.\n"
+                                    )
                         except Exception:
-                            print(f"Log file not found or can't be opened: {self.log_filepath}")
+                            print(
+                                f"Log file not found or can't be opened: {self.log_filepath}"
+                            )
 
             category_ids = [cat["id"] for cat in coco["categories"]]
             image_ids = [img["id"] for img in coco["images"]]
@@ -547,7 +592,7 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains duplicate category IDs. '
-                                   f"Verify that all categories[N].id are unique.",
+                        f"Verify that all categories[N].id are unique.",
                     }
                 )
 
@@ -556,7 +601,7 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains duplicate image IDs. '
-                                   f"Verify that all images[N].id are unique.",
+                        f"Verify that all images[N].id are unique.",
                     }
                 )
 
@@ -565,7 +610,7 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains duplicate annotation IDs. '
-                                   f"Verify that all annotations[N].id are unique.",
+                        f"Verify that all annotations[N].id are unique.",
                     }
                 )
 
@@ -574,10 +619,10 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains annotations with '
-                                   f"non-existent image IDs: "
-                                   f"{list(set(ann_img_ids).difference(set(image_ids)))}. "
-                                   f"Verify all values of annotations[N].image_id are listed under "
-                                   f'images[M].id in "{coco_file_name}".',
+                        f"non-existent image IDs: "
+                        f"{list(set(ann_img_ids).difference(set(image_ids)))}. "
+                        f"Verify all values of annotations[N].image_id are listed under "
+                        f'images[M].id in "{coco_file_name}".',
                     }
                 )
             if not set(ann_cat_ids).issubset(set(category_ids)):
@@ -585,11 +630,11 @@ class DatasetValidator:
                     {
                         "type": "error",
                         "message": f'The annotation file "{coco_file_name}" contains annotations with '
-                                   f"non-existent category IDs: "
-                                   f"{list(set(ann_cat_ids).difference(set(category_ids)))}, "
-                                   f"where the allowed values are {category_ids}. Verify all values of "
-                                   f"annotations[N].category_id are listed under categories[M].id "
-                                   f'in "{coco_file_name}".',
+                        f"non-existent category IDs: "
+                        f"{list(set(ann_cat_ids).difference(set(category_ids)))}, "
+                        f"where the allowed values are {category_ids}. Verify all values of "
+                        f"annotations[N].category_id are listed under categories[M].id "
+                        f'in "{coco_file_name}".',
                     }
                 )
 
@@ -600,7 +645,7 @@ class DatasetValidator:
                     "message": f'The annotation file "{coco_file_name}" is not formatted correctly: {e}.',
                 }
             )
-            
+
         # run pydantic validation
         try:
             CocoDataset.parse_obj(coco)
@@ -631,19 +676,27 @@ class DatasetValidator:
                         hashes[file_hash] = []
                     hashes[file_hash].append(img["id"])
         if duplicate_count > 0:
-            if self.handle_permission('Auto-fix: Do you want to delete duplicate images from your dataset? (y/n): '):
+            if self.handle_permission(
+                "Auto-fix: Do you want to delete duplicate images from your dataset? (y/n): "
+            ):
                 for hash_images in hashes.values():
                     if len(hash_images) > 1:
-                        img_to_keep = [img for img in coco["images"] if img["id"] == hash_images[0]][0]
+                        img_to_keep = [
+                            img for img in coco["images"] if img["id"] == hash_images[0]
+                        ][0]
                         for img_id in hash_images[1:]:
                             try:
                                 img_to_delete = [
-                                    img for img in coco["images"] if
-                                    img["id"] == img_id and img["file_name"] != img_to_keep["file_name"]
+                                    img
+                                    for img in coco["images"]
+                                    if img["id"] == img_id
+                                    and img["file_name"] != img_to_keep["file_name"]
                                 ][0]
                             except IndexError:
                                 continue
-                            img_path = osp.join(self.image_dir, img_to_delete["file_name"])
+                            img_path = osp.join(
+                                self.image_dir, img_to_delete["file_name"]
+                            )
                             # Backup the file before removing it
                             self.backup_file(img_path)
                             os.remove(img_path)
@@ -651,7 +704,9 @@ class DatasetValidator:
                             for ann in coco["annotations"]:
                                 if ann["image_id"] == img_id:
                                     ann["image_id"] = img_to_keep["id"]
-                            coco["images"] = [img for img in coco["images"] if img["id"] != img_id]
+                            coco["images"] = [
+                                img for img in coco["images"] if img["id"] != img_id
+                            ]
                 self.reload_coco(coco_path, coco)
                 # restarting validation due to changes in the dataset
                 self.restart_analysis = True
@@ -659,29 +714,37 @@ class DatasetValidator:
             else:
                 if self.log_filepath is not None:
                     try:
-                        with open(self.log_filepath, 'a') as file:
+                        with open(self.log_filepath, "a") as file:
                             for hash_images in hashes.values():
                                 if len(hash_images) > 1:
-                                    relpaths = [osp.relpath(path, start=self.image_dir) for path in hash_images]
-                                    file.write(f'Images {relpaths} are duplicate.\n')
+                                    relpaths = [
+                                        osp.relpath(path, start=self.image_dir)
+                                        for path in hash_images
+                                    ]
+                                    file.write(f"Images {relpaths} are duplicate.\n")
                     except Exception:
-                        print(f"Log file not found or can't be opened: {self.log_filepath}")
-                return [{
-                    'type': 'warning',
-                    'message': f'There are {duplicate_count} duplicate images (with same content, but different name) '
-                               f'in your dataset. Check the "dataset validator log" file in the Dataset Analysis job '
-                               f'to see details about those images.'}]
+                        print(
+                            f"Log file not found or can't be opened: {self.log_filepath}"
+                        )
+                return [
+                    {
+                        "type": "warning",
+                        "message": f"There are {duplicate_count} duplicate images (with same content, but different name) "
+                        f'in your dataset. Check the "dataset validator log" file in the Dataset Analysis job '
+                        f"to see details about those images.",
+                    }
+                ]
         else:
             return []
 
     def check_for_split_leakage(
-            self,
-            ann_path_1: str,
-            ann_path_2: str,
-            split_name_1: str,
-            split_name_2: str,
-            train_duplicate_threshold_for_error: float = 0.03,
-            test_val_duplicate_threshold_for_error: float = 0.05
+        self,
+        ann_path_1: str,
+        ann_path_2: str,
+        split_name_1: str,
+        split_name_2: str,
+        train_duplicate_threshold_for_error: float = 0.03,
+        test_val_duplicate_threshold_for_error: float = 0.05,
     ):
         try:
             with open(ann_path_1, "r") as f:
@@ -702,10 +765,20 @@ class DatasetValidator:
                 leaked_percentage_of_smaller = len(leaked_images) / min(
                     len(images1), len(images2)
                 )
-                if leaked_percentage_of_smaller > train_duplicate_threshold_for_error and "train" in split_names_lower:
-                    message_type = 'error'
-                if leaked_percentage_of_smaller > test_val_duplicate_threshold_for_error and "test" in split_names_lower and ("val" in split_names_lower or "validation" in split_names_lower):
-                    message_type = 'error'
+                if (
+                    leaked_percentage_of_smaller > train_duplicate_threshold_for_error
+                    and "train" in split_names_lower
+                ):
+                    message_type = "error"
+                if (
+                    leaked_percentage_of_smaller
+                    > test_val_duplicate_threshold_for_error
+                    and "test" in split_names_lower
+                    and (
+                        "val" in split_names_lower or "validation" in split_names_lower
+                    )
+                ):
+                    message_type = "error"
 
                 with open(self.log_filepath, "a") as file:
                     for img in leaked_images:
@@ -714,11 +787,11 @@ class DatasetValidator:
                         )
                 return [
                     {
-                        'type': message_type,
-                        'message': f'Leakage was found between the "{split_name_1}" and "{split_name_2}" dataset splits'
-                                   f' as {len(leaked_images)} images (which represents '
-                                   f'{round(leaked_percentage_of_smaller * 100, 2)}% of the smaller "{smaller_split}" '
-                                   f'split) are duplicated between them.'
+                        "type": message_type,
+                        "message": f'Leakage was found between the "{split_name_1}" and "{split_name_2}" dataset splits'
+                        f" as {len(leaked_images)} images (which represents "
+                        f'{round(leaked_percentage_of_smaller * 100, 2)}% of the smaller "{smaller_split}" '
+                        f"split) are duplicated between them.",
                     }
                 ]
             return []
@@ -736,16 +809,24 @@ class DatasetValidator:
             ]
             if len(duplicates) > 0:
                 if self.handle_permission(
-                        f'Auto-fix: Do you want to delete duplicate images in split "{coco_file_name}"? (y/n): '):
+                    f'Auto-fix: Do you want to delete duplicate images in split "{coco_file_name}"? (y/n): '
+                ):
                     for img, count in duplicates:
                         if count > 1:
-                            indices = [i for i, d in enumerate(coco["images"]) if d["file_name"] == img]
+                            indices = [
+                                i
+                                for i, d in enumerate(coco["images"])
+                                if d["file_name"] == img
+                            ]
                             img_to_remain = coco["images"][indices[0]]
                             for i in indices[1:]:
                                 img_to_delete = coco["images"][i]
                                 # routing all annotations to the image that will remain
-                                anns_for_img = [ann for ann in coco["annotations"] if
-                                                ann["image_id"] == img_to_delete["id"]]
+                                anns_for_img = [
+                                    ann
+                                    for ann in coco["annotations"]
+                                    if ann["image_id"] == img_to_delete["id"]
+                                ]
                                 for ann in anns_for_img:
                                     ann["image_id"] = img_to_remain["id"]
                                 del coco["images"][i]
@@ -753,16 +834,17 @@ class DatasetValidator:
                     self.restart_analysis = True
                     return []
                 else:
-                    with open(self.log_filepath, 'a') as file:
+                    with open(self.log_filepath, "a") as file:
                         for img in duplicates:
                             file.write(
                                 f'Image "{img[0]}" is duplicated {img[1]} times in the "{coco_file_name}" annotation '
-                                f'file.\n')
+                                f"file.\n"
+                            )
                     return [
                         {
-                            'type': 'warning',
-                            'message': f'{len(duplicates)} images are duplicated in the {coco_file_name} annotation '
-                                       f'file.'
+                            "type": "warning",
+                            "message": f"{len(duplicates)} images are duplicated in the {coco_file_name} annotation "
+                            f"file.",
                         }
                     ]
             return []
@@ -770,9 +852,9 @@ class DatasetValidator:
             return []
 
     def validate_split_sizes(
-            self,
-            dataset_infos_path: str,
-            split_names: str,
+        self,
+        dataset_infos_path: str,
+        split_names: str,
     ):
         split_messages = []
         with open(dataset_infos_path, "r") as f:
@@ -793,15 +875,17 @@ class DatasetValidator:
                             if not self.auto_fix:
                                 split_messages.append(
                                     {
-                                        'type': 'warning',
-                                        'message': f'"dataset_infos.json" shows {split_dict["num_examples"]} as number'
-                                                   f' of images in split "{split_name}", but {real_num_examples} images'
-                                                   f' were found in the dataset root directory.'
+                                        "type": "warning",
+                                        "message": f'"dataset_infos.json" shows {split_dict["num_examples"]} as number'
+                                        f' of images in split "{split_name}", but {real_num_examples} images'
+                                        f" were found in the dataset root directory.",
                                     }
                                 )
                             else:
                                 split_dict["num_examples"] = real_num_examples
-                                self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
+                                self.reload_dataset_infos(
+                                    dataset_infos_path, dataset_infos_json
+                                )
                                 log.debug(
                                     f"Auto-fix: changed num_examples for split {split_name} to {real_num_examples}"
                                 )
@@ -809,29 +893,37 @@ class DatasetValidator:
                         if not self.auto_fix:
                             split_messages.append(
                                 {
-                                    'type': 'warning',
-                                    'message': f'"dataset_infos.json" doesn\'t contain a valid entry for '
-                                               f'"num_examples" for split "{split_name}", {real_num_examples} images '
-                                               f'were found in the dataset root directory.'
+                                    "type": "warning",
+                                    "message": f'"dataset_infos.json" doesn\'t contain a valid entry for '
+                                    f'"num_examples" for split "{split_name}", {real_num_examples} images '
+                                    f"were found in the dataset root directory.",
                                 }
                             )
                         else:
                             split_dict["num_examples"] = real_num_examples
-                            self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                            log.debug(f"Auto-fix: added num_examples for split {split_name}: {real_num_examples}")
+                            self.reload_dataset_infos(
+                                dataset_infos_path, dataset_infos_json
+                            )
+                            log.debug(
+                                f"Auto-fix: added num_examples for split {split_name}: {real_num_examples}"
+                            )
                 else:
                     if not self.auto_fix:
                         split_messages.append(
                             {
-                                'type': 'warning',
-                                'message': f'"dataset_infos.json" doesn\'t contain an entry for "num_examples" for '
-                                           f'split "{split_name}".'
+                                "type": "warning",
+                                "message": f'"dataset_infos.json" doesn\'t contain an entry for "num_examples" for '
+                                f'split "{split_name}".',
                             }
                         )
                     else:
                         split_dict["num_examples"] = real_num_examples
-                        self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                        log.debug(f"Auto-fix: added num_examples for split {split_name}: {real_num_examples}")
+                        self.reload_dataset_infos(
+                            dataset_infos_path, dataset_infos_json
+                        )
+                        log.debug(
+                            f"Auto-fix: added num_examples for split {split_name}: {real_num_examples}"
+                        )
 
                 real_bytes = _calculate_split_size(coco_dict, self.image_dir)
                 if "num_bytes" in split_dict:
@@ -840,58 +932,72 @@ class DatasetValidator:
                             if not self.auto_fix:
                                 split_messages.append(
                                     {
-                                        'type': 'warning',
-                                        'message': f'"dataset_infos.json" shows {split_dict["num_bytes"]} B as size of'
-                                                   f' split "{split_name}", but real split size was calculated as '
-                                                   f'{real_bytes} B.'
+                                        "type": "warning",
+                                        "message": f'"dataset_infos.json" shows {split_dict["num_bytes"]} B as size of'
+                                        f' split "{split_name}", but real split size was calculated as '
+                                        f"{real_bytes} B.",
                                     }
                                 )
                             else:
                                 split_dict["num_bytes"] = real_bytes
-                                self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                                log.debug(f"Auto-fix: changed num_bytes for split {split_name} to {real_bytes}")
+                                self.reload_dataset_infos(
+                                    dataset_infos_path, dataset_infos_json
+                                )
+                                log.debug(
+                                    f"Auto-fix: changed num_bytes for split {split_name} to {real_bytes}"
+                                )
                     else:
                         if not self.auto_fix:
                             split_messages.append(
                                 {
-                                    'type': 'warning',
-                                    'message': f'"dataset_infos.json" doesn\'t contain a valid entry for "num_bytes" '
-                                               f'for split "{split_name}", real split size was calculated as'
-                                               f' {real_bytes} B.'
+                                    "type": "warning",
+                                    "message": f'"dataset_infos.json" doesn\'t contain a valid entry for "num_bytes" '
+                                    f'for split "{split_name}", real split size was calculated as'
+                                    f" {real_bytes} B.",
                                 }
                             )
                         else:
                             split_dict["num_bytes"] = real_bytes
-                            self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                            log.debug(f"Auto-fix: added num_bytes for split {split_name}: {real_bytes}")
+                            self.reload_dataset_infos(
+                                dataset_infos_path, dataset_infos_json
+                            )
+                            log.debug(
+                                f"Auto-fix: added num_bytes for split {split_name}: {real_bytes}"
+                            )
                 else:
                     if not self.auto_fix:
                         split_messages.append(
                             {
-                                'type': 'warning',
-                                'message': f'"dataset_infos.json" doesn\'t contain an entry for '
-                                           f'"num_bytes" for split "{split_name}".'
+                                "type": "warning",
+                                "message": f'"dataset_infos.json" doesn\'t contain an entry for '
+                                f'"num_bytes" for split "{split_name}".',
                             }
                         )
                     else:
                         split_dict["num_bytes"] = real_bytes
-                        self.reload_dataset_infos(dataset_infos_path, dataset_infos_json)
-                        log.debug(f"Auto-fix: added num_bytes for split {split_name}: {real_bytes}")
+                        self.reload_dataset_infos(
+                            dataset_infos_path, dataset_infos_json
+                        )
+                        log.debug(
+                            f"Auto-fix: added num_bytes for split {split_name}: {real_bytes}"
+                        )
             except Exception:
                 split_messages.append(
                     {
-                        'type': 'error',
-                        'message': f'Couldn\'t verify size and number of images for split "{split_name}".'
+                        "type": "error",
+                        "message": f'Couldn\'t verify size and number of images for split "{split_name}".',
                     }
                 )
 
         return split_messages
 
     def _create_param_error_message(self, coco_file_name: str, param_name: str):
-        return [{
-            "type": "error",
-            "message": f'The annotation file "{coco_file_name}" is missing required parameter "{param_name}"'
-        }]
+        return [
+            {
+                "type": "error",
+                "message": f'The annotation file "{coco_file_name}" is missing required parameter "{param_name}"',
+            }
+        ]
 
     def param_check(self, coco: dict, coco_file_name: str):
         """
@@ -918,14 +1024,18 @@ class DatasetValidator:
             if "id" not in cat:
                 return self._create_param_error_message(coco_file_name, "categories.id")
             if "name" not in cat:
-                return self._create_param_error_message(coco_file_name, "categories.name")
+                return self._create_param_error_message(
+                    coco_file_name, "categories.name"
+                )
 
         # images.* checks
         for img in coco["images"]:
             if "id" not in img:
                 return self._create_param_error_message(coco_file_name, "images.id")
             if "file_name" not in img:
-                return self._create_param_error_message(coco_file_name, "images.file_name")
+                return self._create_param_error_message(
+                    coco_file_name, "images.file_name"
+                )
             if "width" not in img:
                 return self._create_param_error_message(coco_file_name, "images.width")
             if "height" not in img:
@@ -934,18 +1044,24 @@ class DatasetValidator:
         # annotations.* checks
         for ann in coco["annotations"]:
             if "id" not in ann:
-                return self._create_param_error_message(coco_file_name, "annotations.id")
+                return self._create_param_error_message(
+                    coco_file_name, "annotations.id"
+                )
             if "image_id" not in ann:
-                return self._create_param_error_message(coco_file_name, "annotations.image_id")
+                return self._create_param_error_message(
+                    coco_file_name, "annotations.image_id"
+                )
             if "category_id" not in ann:
-                return self._create_param_error_message(coco_file_name, "annotations.category_id")
+                return self._create_param_error_message(
+                    coco_file_name, "annotations.category_id"
+                )
 
         # No errors found
         return []
 
     def handle_permission(self, message):
         if self.auto_fix_2 == UserChoice.PROMPT:
-            return input(message) == 'y'
+            return input(message) == "y"
         elif self.auto_fix_2 == UserChoice.YES:
             return True
         else:
@@ -1054,7 +1170,7 @@ def _calculate_coco_dataset_size(img_dir: str, ann_dir: str, ann_file_names: Lis
             coco = COCO(ann_path)
             imgs = coco.loadImgs(coco.getImgIds())
             for img in imgs:
-                img_path = osp.join(img_dir, img['file_name'])
+                img_path = osp.join(img_dir, img["file_name"])
                 if osp.exists(img_path):
                     size += osp.getsize(img_path)
     return size
@@ -1082,19 +1198,19 @@ def _get_first_image_from_dir(image_dir: str) -> Optional[str]:
     for subdir, dirs, files in os.walk(image_dir):
         for file in files:
             # Check for image file extensions. You can add or remove as needed.
-            if file.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif')):
+            if file.lower().endswith((".png", ".jpg", ".jpeg", ".bmp", ".gif")):
                 return os.path.join(subdir, file)
 
     return None
 
 
 def _reload_dataset_infos(dataset_infos_path: str, dataset_info_dict: dict) -> None:
-    with open(dataset_infos_path, 'w') as file:
+    with open(dataset_infos_path, "w") as file:
         json.dump(dataset_info_dict, file, indent=4)
 
 
 def _reload_coco(coco_file_path: str, coco_dict: dict) -> None:
-    with open(coco_file_path, 'w') as file:
+    with open(coco_file_path, "w") as file:
         json.dump(coco_dict, file, indent=4)
 
 
@@ -1108,11 +1224,11 @@ def validate_cli():
         required=True,
     )
     parser.add_argument(
-        '--auto-fix',
-        '-af',
-        action='store_true',
+        "--auto-fix",
+        "-af",
+        action="store_true",
         default=False,
-        help='Auto-fix smaller issues about your dataset (in dataset_infos.json, not touching images or annotations). Resolves most warnings.',
+        help="Auto-fix smaller issues about your dataset (in dataset_infos.json, not touching images or annotations). Resolves most warnings.",
     )
     parser.add_argument(
         "--auto-fix-2",
@@ -1126,13 +1242,23 @@ def validate_cli():
             "  p : prompt each time"
         ),
     )
-    parser.add_argument('--verbose', '-v', action='count', required=False, default=0,
-                        help="Verbosity level: -v, -vv")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        required=False,
+        default=0,
+        help="Verbosity level: -v, -vv",
+    )
 
     args = parser.parse_args()
 
     modelcatconnector_version = importlib.metadata.version("modelcat")
-    print(f'ModelCatConnector (v{modelcatconnector_version}) - dataset validation utility'.center(100))
+    print(
+        f"ModelCatConnector (v{modelcatconnector_version}) - dataset validation utility".center(
+            100
+        )
+    )
 
     if args.verbose:
         print(f"Validating dataset with args: {args}.")

--- a/tests/test_annotation_validator.py
+++ b/tests/test_annotation_validator.py
@@ -1,0 +1,385 @@
+import json
+import copy
+import unittest
+import os.path as osp
+from pydantic import ValidationError
+from modelcat.connector.utils.schemas.annotation import CocoDataset
+from modelcat.connector.utils.misc import _get_dataset_path
+
+
+def valid_base_dataset():
+    """
+    Returns a minimal valid dataset dict with:
+    - 1 license
+    - 1 category (no keypoints)
+    - 1 image
+    - 1 annotation (no bbox/keypoints)
+    """
+    return {
+        "info": {"year": "2025", "version": "1.0"},
+        "licenses": [{"id": 1, "name": "MIT"}],
+        "categories": [{"id": 1, "name": "cat"}],
+        "images": [{"id": 1, "file_name": "img_0001.jpg", "license": 1}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [],
+                "segmentation": None,
+                "iscrowd": None,
+                "area": None,
+                "keypoints": None,
+                "num_keypoints": None,
+            }
+        ],
+    }
+
+
+def valid_kp_dataset(K=4):
+    """
+    Minimal valid dataset for a keypointed category with K keypoints.
+    """
+    ds = {
+        "info": {"year": "2025"},
+        "licenses": [{"id": 1}],
+        "categories": [
+            {"id": 1, "name": "person", "keypoints": [f"k{i}" for i in range(K)]}
+        ],
+        "images": [{"id": 1, "file_name": "img.jpg", "license": 1, "width": 100, "height": 100}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                # 3*K numbers: (x,y,v) repeating; all visible (v=2) at (0,0) is allowed by your validator
+                "keypoints": sum(([0, 0, 2] for _ in range(K)), []),
+                "num_keypoints": K,
+                "bbox": [],
+                "segmentation": None,
+                "iscrowd": 0,
+                "area": None,
+            }
+        ],
+    }
+    return ds
+
+
+class TestCocoSchemaFailures(unittest.TestCase):
+    # category validator failures
+    def test_category_keypoints_not_list(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = "not-a-list"
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_category_keypoints_not_strings(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = [1, 2]
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_category_keypoints_empty_strings(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["ok", "  "]
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_skeleton_not_list(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        data["categories"][0]["skeleton"] = "not-a-list"
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_skeleton_bad_pair_shape(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        data["categories"][0]["skeleton"] = [[1, 2], [3]]  # second pair invalid
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_skeleton_non_int_indices(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        data["categories"][0]["skeleton"] = [["1", 2]]
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_skeleton_zero_or_negative(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        data["categories"][0]["skeleton"] = [[0, 2]]
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    def test_skeleton_out_of_range(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        data["categories"][0]["skeleton"] = [[1, 3]]  # only 2 keypoints
+        with self.assertRaises(ValidationError):
+            CocoDataset.parse_obj(data)
+
+    # image failures
+    def test_image_missing_license_reference(self):
+        data = valid_base_dataset()
+        data["images"][0]["license"] = 999
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("references unknown license id", str(ctx.exception))
+
+    def test_image_empty_filename(self):
+        data = valid_base_dataset()
+        data["images"][0]["file_name"] = "   "
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("non-empty 'file_name'", str(ctx.exception))
+
+    def test_duplicate_image_filenames(self):
+        data = valid_base_dataset()
+        data["images"].append({"id": 2, "file_name": "img_0001.jpg", "license": 1})
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Duplicate image file_name", str(ctx.exception))
+
+    # annotation field validator failures
+    def test_bbox_wrong_length(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["bbox"] = [1, 2, 3]  # not 4
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("bbox must have 4 elements", str(ctx.exception))
+
+    def test_bbox_non_numeric(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["bbox"] = [0, "y", 10, 10]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("value is not a valid", str(ctx.exception))
+
+    def test_bbox_negative(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["bbox"] = [0, 0, -5, 10]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("bbox values must be non-negative", str(ctx.exception))
+
+    def test_keypoints_not_list_or_bad_mod(self):
+        data = valid_base_dataset()
+        data["categories"][0]["keypoints"] = ["a", "b"]
+        # root validator will require ann.keypoints present; give wrong shape to trigger field validator
+        data["annotations"][0]["keypoints"] = [0, 0, 2, 1]  # len%3 != 0
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("keypoints must be a flat list", str(ctx.exception))
+
+    def test_keypoints_bad_visibility_value(self):
+        data = valid_kp_dataset(K=2)
+        data["annotations"][0]["keypoints"][2] = 9  # v must be 0,1,2
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("visibility values must be 0,1,2", str(ctx.exception))
+
+    def test_keypoints_v0_requires_zero_coords(self):
+        data = valid_kp_dataset(K=2)
+        # set first triplet to v=0 but coords not zero
+        data["annotations"][0]["keypoints"][:3] = [5, 5, 0]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("When visibility v=0", str(ctx.exception))
+
+    def test_keypoints_visible_coords_must_be_non_negative(self):
+        data = valid_kp_dataset(K=2)
+        # make one visible kp negative
+        data["annotations"][0]["keypoints"][0:3] = [-1, 0, 2]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Visible keypoints must have non-negative coordinates", str(ctx.exception))
+
+    def test_iscrowd_invalid(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["iscrowd"] = 2  # not 0/1
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("iscrowd must be integer 0 or 1", str(ctx.exception))
+
+    # root validator failures: uniqueness
+    def test_duplicate_license_ids(self):
+        data = valid_base_dataset()
+        data["licenses"].append({"id": 1, "name": "dup"})
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Duplicate license id", str(ctx.exception))
+
+    def test_duplicate_category_ids(self):
+        data = valid_base_dataset()
+        data["categories"].append({"id": 1, "name": "dog"})
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Category ids must be contiguous", str(ctx.exception))
+
+    def test_duplicate_image_ids(self):
+        data = valid_base_dataset()
+        data["images"].append({"id": 1, "file_name": "img_0002.jpg", "license": 1})
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Duplicate image id", str(ctx.exception))
+
+    def test_duplicate_annotation_ids(self):
+        data = valid_base_dataset()
+        ann = copy.deepcopy(data["annotations"][0])
+        ann["id"] = 1
+        ann["image_id"] = 1
+        ann["category_id"] = 1
+        data["annotations"].append(ann)
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Duplicate annotation id", str(ctx.exception))
+
+    # root validator failures: category name uniqueness
+    def test_duplicate_category_names(self):
+        data = valid_base_dataset()
+        data["categories"] = [{"id": 1, "name": "cat"}, {"id": 2, "name": "cat"}]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Duplicate category name", str(ctx.exception))
+
+    # root validator failures: category ids must be contiguous starting at 1
+    def test_category_ids_not_contiguous_from_1(self):
+        data = valid_base_dataset()
+        data["categories"] = [{"id": 1, "name": "a"}, {"id": 3, "name": "b"}]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("Category ids must be contiguous starting at 1", str(ctx.exception))
+
+    # root validator failures: invalid foreign keys
+    def test_annotation_unknown_image_id(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["image_id"] = 999
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("references unknown image_id", str(ctx.exception))
+
+    def test_annotation_unknown_category_id(self):
+        data = valid_base_dataset()
+        data["annotations"][0]["category_id"] = 999
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("references unknown category_id", str(ctx.exception))
+
+    # root validator failures: keypoints rules when category has keypoints
+    def test_kp_category_requires_ann_keypoints_presence(self):
+        data = valid_kp_dataset(K=3)
+        # remove keypoints to trigger "must include 'keypoints'"
+        data["annotations"][0]["keypoints"] = None
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("must include 'keypoints'", str(ctx.exception))
+
+    def test_kp_category_keypoints_length_mismatch(self):
+        data = valid_kp_dataset(K=3)
+        # have only 2*3 numbers instead of 3*3
+        data["annotations"][0]["keypoints"] = [0, 0, 2, 0, 0, 2]
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("keypoints length must be", str(ctx.exception))
+
+    def test_kp_category_num_keypoints_mismatch(self):
+        data = valid_kp_dataset(K=3)
+        # make only 2 visible (set one triplet to v=0 with (0,0))
+        data["annotations"][0]["keypoints"] = [0, 0, 2, 0, 0, 2, 0, 0, 0]
+        data["annotations"][0]["num_keypoints"] = 3
+        with self.assertRaises(ValidationError) as ctx:
+            CocoDataset.parse_obj(data)
+        self.assertIn("num_keypoints=", str(ctx.exception))
+
+
+def _load_coco(path: str) -> CocoDataset:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return CocoDataset.parse_obj(data)
+
+
+class TestCocoDatasetSuccess(unittest.TestCase):
+    def _assert_basic_coco_integrity(self, coco: CocoDataset):
+        # sanity: the model parsed, and lists are present
+        self.assertIsInstance(coco.categories, list)
+        self.assertIsInstance(coco.images, list)
+        self.assertIsInstance(coco.annotations, list)
+        self.assertGreaterEqual(len(coco.categories), 1)
+        self.assertGreater(len(coco.images), 0)
+
+        # every annotation image_id & category_id must be known (the model already enforces this;
+        # these checks document expectations and give clearer assertion failures if something changes)
+        cat_ids = {c.id for c in coco.categories}
+        img_ids = {im.id for im in coco.images}
+        for ann in coco.annotations:
+            self.assertIn(ann.category_id, cat_ids, f"unknown category_id {ann.category_id} in ann {ann.id}")
+            self.assertIn(ann.image_id, img_ids, f"unknown image_id {ann.image_id} in ann {ann.id}")
+
+        # segmentation should always be present (validator defaults to [[]])
+        for ann in coco.annotations:
+            self.assertIsNotNone(ann.segmentation)
+
+        # file_name must be present and non-empty
+        for im in coco.images:
+            self.assertTrue(isinstance(im.file_name, str) and im.file_name.strip())
+
+    def _assert_classification_rules(self, coco: CocoDataset):
+        # in sample classification split, bbox is empty for all annotations
+        for ann in coco.annotations:
+            self.assertTrue(ann.bbox == [] or ann.bbox is None)
+
+    def _assert_detection_rules(self, coco: CocoDataset):
+        # for detection, each annotation must have a 4-element bbox (model enforces this when provided;
+        # these asserts document the intended dataset convention)
+        for ann in coco.annotations:
+            self.assertIsInstance(ann.bbox, list)
+            # some datasets allow crowd-only anns without bbox; sample shows bbox for all.
+            self.assertEqual(len(ann.bbox), 4, f"ann {ann.id} missing 4-element bbox")
+
+    def _assert_keypoints_rules(self, coco: CocoDataset):
+        # map category_id -> expected K (or None if no keypoints)
+        cat_to_k = {c.id: (len(c.keypoints) if c.keypoints else None) for c in coco.categories}
+        for ann in coco.annotations:
+            K = cat_to_k.get(ann.category_id)
+            if K:
+                self.assertIsInstance(ann.keypoints, list, f"ann {ann.id} must include keypoints")
+                self.assertEqual(len(ann.keypoints), 3 * K, f"ann {ann.id} keypoints length must be 3*K")
+                # if num_keypoints present, it must match count of v>0
+                if ann.num_keypoints is not None:
+                    visible = sum(1 for i in range(2, len(ann.keypoints), 3) if int(ann.keypoints[i]) > 0)
+                    self.assertEqual(
+                        ann.num_keypoints, visible, f"ann {ann.id} num_keypoints mismatch (got {ann.num_keypoints}, vis {visible})"
+                    )
+
+    # classification sample
+    def test_load_sample_coco_classification(self):
+        ds_path = osp.join(_get_dataset_path(), "classification_sample")
+        for split in ("coco_train.json", "coco_validation.json", "coco_test.json"):
+            with self.subTest(split=split):
+                coco = _load_coco(osp.join(ds_path, "annotations", split))
+                self._assert_basic_coco_integrity(coco)
+                self._assert_classification_rules(coco)
+
+    # object detection sample
+    def test_load_sample_coco_detection(self):
+        ds_path = osp.join(_get_dataset_path(), "objectdetection_sample")
+        for split in ("coco_train.json", "coco_validation.json", "coco_test.json"):
+            with self.subTest(split=split):
+                coco = _load_coco(osp.join(ds_path, "annotations", split))
+                self._assert_basic_coco_integrity(coco)
+                self._assert_detection_rules(coco)
+
+    # keypoints detection sample
+    def test_load_sample_coco_keypoints(self):
+        ds_path = osp.join(_get_dataset_path(), "keypoints_sample")
+        for split in ("coco_train.json", "coco_validation.json", "coco_test.json"):
+            with self.subTest(split=split):
+                coco = _load_coco(osp.join(ds_path, "annotations", split))
+                self._assert_basic_coco_integrity(coco)
+                self._assert_keypoints_rules(coco)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_annotation_validator.py
+++ b/tests/test_annotation_validator.py
@@ -44,9 +44,16 @@ def valid_kp_dataset(K=4):
         "info": {"year": "2025"},
         "licenses": [{"id": 1}],
         "categories": [
-            {"id": 1, "name": "person", "supercategory": "person", "keypoints": [f"k{i}" for i in range(K)]}
+            {
+                "id": 1,
+                "name": "person",
+                "supercategory": "person",
+                "keypoints": [f"k{i}" for i in range(K)],
+            }
         ],
-        "images": [{"id": 1, "file_name": "img.jpg", "license": 1, "width": 100, "height": 100}],
+        "images": [
+            {"id": 1, "file_name": "img.jpg", "license": 1, "width": 100, "height": 100}
+        ],
         "annotations": [
             {
                 "id": 1,
@@ -194,7 +201,9 @@ class TestCocoSchemaFailures(unittest.TestCase):
         data["annotations"][0]["keypoints"][0:3] = [-1, 0, 2]
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
-        self.assertIn("Visible keypoints must have non-negative coordinates", str(ctx.exception))
+        self.assertIn(
+            "Visible keypoints must have non-negative coordinates", str(ctx.exception)
+        )
 
     def test_iscrowd_invalid(self):
         data = valid_base_dataset()
@@ -239,7 +248,10 @@ class TestCocoSchemaFailures(unittest.TestCase):
     # root validator failures: category name uniqueness
     def test_duplicate_category_names(self):
         data = valid_base_dataset()
-        data["categories"] = [{"id": 1, "name": "cat", "supercategory": "animal"}, {"id": 2, "name": "cat", "supercategory": "animal"}]
+        data["categories"] = [
+            {"id": 1, "name": "cat", "supercategory": "animal"},
+            {"id": 2, "name": "cat", "supercategory": "animal"},
+        ]
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
         self.assertIn("Duplicate category name", str(ctx.exception))
@@ -247,10 +259,15 @@ class TestCocoSchemaFailures(unittest.TestCase):
     # root validator failures: category ids must be contiguous starting at 1
     def test_category_ids_not_contiguous_from_1(self):
         data = valid_base_dataset()
-        data["categories"] = [{"id": 1, "name": "a", "supercategory": "animal"}, {"id": 3, "name": "b", "supercategory": "animal"}]
+        data["categories"] = [
+            {"id": 1, "name": "a", "supercategory": "animal"},
+            {"id": 3, "name": "b", "supercategory": "animal"},
+        ]
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
-        self.assertIn("Category ids must be contiguous starting at 1", str(ctx.exception))
+        self.assertIn(
+            "Category ids must be contiguous starting at 1", str(ctx.exception)
+        )
 
     # root validator failures: invalid foreign keys
     def test_annotation_unknown_image_id(self):
@@ -314,8 +331,16 @@ class TestCocoDatasetSuccess(unittest.TestCase):
         cat_ids = {c.id for c in coco.categories}
         img_ids = {im.id for im in coco.images}
         for ann in coco.annotations:
-            self.assertIn(ann.category_id, cat_ids, f"unknown category_id {ann.category_id} in ann {ann.id}")
-            self.assertIn(ann.image_id, img_ids, f"unknown image_id {ann.image_id} in ann {ann.id}")
+            self.assertIn(
+                ann.category_id,
+                cat_ids,
+                f"unknown category_id {ann.category_id} in ann {ann.id}",
+            )
+            self.assertIn(
+                ann.image_id,
+                img_ids,
+                f"unknown image_id {ann.image_id} in ann {ann.id}",
+            )
 
         # segmentation should always be present (validator defaults to [[]])
         for ann in coco.annotations:
@@ -340,17 +365,31 @@ class TestCocoDatasetSuccess(unittest.TestCase):
 
     def _assert_keypoints_rules(self, coco: CocoDataset):
         # map category_id -> expected K (or None if no keypoints)
-        cat_to_k = {c.id: (len(c.keypoints) if c.keypoints else None) for c in coco.categories}
+        cat_to_k = {
+            c.id: (len(c.keypoints) if c.keypoints else None) for c in coco.categories
+        }
         for ann in coco.annotations:
             K = cat_to_k.get(ann.category_id)
             if K:
-                self.assertIsInstance(ann.keypoints, list, f"ann {ann.id} must include keypoints")
-                self.assertEqual(len(ann.keypoints), 3 * K, f"ann {ann.id} keypoints length must be 3*K")
+                self.assertIsInstance(
+                    ann.keypoints, list, f"ann {ann.id} must include keypoints"
+                )
+                self.assertEqual(
+                    len(ann.keypoints),
+                    3 * K,
+                    f"ann {ann.id} keypoints length must be 3*K",
+                )
                 # if num_keypoints present, it must match count of v>0
                 if ann.num_keypoints is not None:
-                    visible = sum(1 for i in range(2, len(ann.keypoints), 3) if int(ann.keypoints[i]) > 0)
+                    visible = sum(
+                        1
+                        for i in range(2, len(ann.keypoints), 3)
+                        if int(ann.keypoints[i]) > 0
+                    )
                     self.assertEqual(
-                        ann.num_keypoints, visible, f"ann {ann.id} num_keypoints mismatch (got {ann.num_keypoints}, vis {visible})"
+                        ann.num_keypoints,
+                        visible,
+                        f"ann {ann.id} num_keypoints mismatch (got {ann.num_keypoints}, vis {visible})",
                     )
 
     # classification sample

--- a/tests/test_annotation_validator.py
+++ b/tests/test_annotation_validator.py
@@ -18,7 +18,7 @@ def valid_base_dataset():
     return {
         "info": {"year": "2025", "version": "1.0"},
         "licenses": [{"id": 1, "name": "MIT"}],
-        "categories": [{"id": 1, "name": "cat"}],
+        "categories": [{"id": 1, "name": "cat", "supercategory": "animal"}],
         "images": [{"id": 1, "file_name": "img_0001.jpg", "license": 1}],
         "annotations": [
             {
@@ -44,7 +44,7 @@ def valid_kp_dataset(K=4):
         "info": {"year": "2025"},
         "licenses": [{"id": 1}],
         "categories": [
-            {"id": 1, "name": "person", "keypoints": [f"k{i}" for i in range(K)]}
+            {"id": 1, "name": "person", "supercategory": "person", "keypoints": [f"k{i}" for i in range(K)]}
         ],
         "images": [{"id": 1, "file_name": "img.jpg", "license": 1, "width": 100, "height": 100}],
         "annotations": [
@@ -213,7 +213,7 @@ class TestCocoSchemaFailures(unittest.TestCase):
 
     def test_duplicate_category_ids(self):
         data = valid_base_dataset()
-        data["categories"].append({"id": 1, "name": "dog"})
+        data["categories"].append({"id": 1, "name": "dog", "supercategory": "animal"})
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
         self.assertIn("Category ids must be contiguous", str(ctx.exception))
@@ -239,7 +239,7 @@ class TestCocoSchemaFailures(unittest.TestCase):
     # root validator failures: category name uniqueness
     def test_duplicate_category_names(self):
         data = valid_base_dataset()
-        data["categories"] = [{"id": 1, "name": "cat"}, {"id": 2, "name": "cat"}]
+        data["categories"] = [{"id": 1, "name": "cat", "supercategory": "animal"}, {"id": 2, "name": "cat", "supercategory": "animal"}]
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
         self.assertIn("Duplicate category name", str(ctx.exception))
@@ -247,7 +247,7 @@ class TestCocoSchemaFailures(unittest.TestCase):
     # root validator failures: category ids must be contiguous starting at 1
     def test_category_ids_not_contiguous_from_1(self):
         data = valid_base_dataset()
-        data["categories"] = [{"id": 1, "name": "a"}, {"id": 3, "name": "b"}]
+        data["categories"] = [{"id": 1, "name": "a", "supercategory": "animal"}, {"id": 3, "name": "b", "supercategory": "animal"}]
         with self.assertRaises(ValidationError) as ctx:
             CocoDataset.parse_obj(data)
         self.assertIn("Category ids must be contiguous starting at 1", str(ctx.exception))

--- a/tests/test_datainfo_schema_validator.py
+++ b/tests/test_datainfo_schema_validator.py
@@ -198,7 +198,7 @@ class TestSplitsWithDicts(unittest.TestCase):
             DatasetInfo.parse_obj(payload)
 
     def test_splitinfo_required_fields_via_dict(self):
-        # Split missing required 'dataset_name'
+        # split missing required 'dataset_name'
         payload = {
             "task_templates": [{"task": "classification", "labels": ["x"]}],
             "splits": {
@@ -241,7 +241,7 @@ class TestFeaturesWithDicts(unittest.TestCase):
             "features": {
                 "image": {"_type": "Image"},
                 "labels": {"_type": "Sequence"},
-                "image/filename": {"_type": "Text"},  # extra key allowed? depends on your Features.Config
+                "image/filename": {"_type": "Text"},
                 "objects": {
                     "_type": "Sequence",
                     "objects_bbox": {"_type": "BBoxFeature"},
@@ -249,12 +249,8 @@ class TestFeaturesWithDicts(unittest.TestCase):
                 },
             },
         }
-        try:
-            di = DatasetInfo.parse_obj(payload)
-            self.assertEqual(di.features.image.type, "Image")
-        except ValidationError as e:
-            # If you disallow extras, assert that it does fail.
-            self.assertIsInstance(e, ValidationError)
+        di = DatasetInfo.parse_obj(payload)
+        self.assertEqual(di.features.image.type, "Image")
 
 
 class TestDatasetInfosWithDicts(unittest.TestCase):

--- a/tests/test_datainfo_schema_validator.py
+++ b/tests/test_datainfo_schema_validator.py
@@ -1,0 +1,333 @@
+import json
+import unittest
+import os.path as osp
+from pydantic import ValidationError
+from modelcat.connector.utils.schemas.datainfo import DatasetInfo, DatasetInfos
+from modelcat.connector.utils.misc import _get_dataset_path
+
+
+def minimal_splits_dict():
+    return {
+        "train": {
+            "name": "train",
+            "dataset_name": "coco_train.json",
+            "num_examples": 100,
+            "num_bytes": 1234,
+        },
+        "validation": {
+            "name": "validation",
+            "dataset_name": "coco_val.json",
+            "num_examples": 20,
+            "num_bytes": 234,
+        },
+        "test": {
+            "name": "test",
+            "dataset_name": "coco_test.json",
+            "num_examples": 20,
+            "num_bytes": 345,
+        },
+    }
+
+
+class TestTaskTemplateWithDicts(unittest.TestCase):
+    def test_classification_minimal_dict(self):
+        payload = {
+            "task_templates": [
+                {"task": "classification", "labels": ["cat", "dog"]}
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertEqual(di.task_templates[0].task, "classification")
+        self.assertEqual(di.task_templates[0].labels, ["cat", "dog"])
+
+    def test_detection_minimal_dict(self):
+        payload = {
+            "task_templates": [
+                {"task": "detection", "labels": ["person"]}
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertEqual(di.task_templates[0].task, "detection")
+
+    def test_keypoints_requires_num_keypoints(self):
+        payload = {
+            "task_templates": [
+                {"task": "keypoints", "labels": ["person"]}  # missing num_keypoints
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            DatasetInfo.parse_obj(payload)
+        self.assertIn("num_keypoints", str(ctx.exception))
+
+    def test_keypoints_num_keypoints_must_be_positive_int(self):
+        for bad in [0, -1, 3.14, "8", None]:
+            with self.subTest(bad=bad):
+                payload = {
+                    "task_templates": [
+                        {"task": "keypoints", "labels": ["person"], "num_keypoints": bad}
+                    ],
+                    "splits": minimal_splits_dict(),
+                }
+                with self.assertRaises(ValidationError):
+                    DatasetInfo.parse_obj(payload)
+
+        ok_payload = {
+            "task_templates": [
+                {"task": "keypoints", "labels": ["person"], "num_keypoints": 8}
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        di = DatasetInfo.parse_obj(ok_payload)
+        self.assertEqual(di.task_templates[0].num_keypoints, 8)
+
+    def test_annotations_subset_enforced_when_provided(self):
+        # classification requires {"category_id"}
+        payload = {
+            "task_templates": [
+                {"task": "classification", "labels": ["x"], "annotations": ["id"]}
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+        # detection requires {"category_id", "bbox"}
+        payload = {
+            "task_templates": [
+                {"task": "detection", "labels": ["x"], "annotations": ["category_id"]}
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+        # keypoints requires {"category_id", "bbox", "keypoints"}
+        payload = {
+            "task_templates": [
+                {
+                    "task": "keypoints",
+                    "labels": ["x"],
+                    "num_keypoints": 5,
+                    "annotations": ["bbox", "category_id"],
+                }
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+        # ok with required subset + extras
+        payload = {
+            "task_templates": [
+                {
+                    "task": "keypoints",
+                    "labels": ["x"],
+                    "num_keypoints": 5,
+                    "annotations": ["category_id", "bbox", "keypoints", "id", "area"],
+                }
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertEqual(di.task_templates[0].task, "keypoints")
+
+    def test_task_literal_invalid(self):
+        payload = {
+            "task_templates": [
+                {"task": "segmentation", "labels": ["x"]}  # invalid Literal
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+    def test_exactly_one_task_template_required(self):
+        # none
+        payload = {"task_templates": [], "splits": minimal_splits_dict()}
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+        # two
+        payload = {
+            "task_templates": [
+                {"task": "detection", "labels": ["a"]},
+                {"task": "classification", "labels": ["b"]},
+            ],
+            "splits": minimal_splits_dict(),
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+
+class TestSplitsWithDicts(unittest.TestCase):
+    def test_three_required_splits_present(self):
+        payload = {
+            "task_templates": [{"task": "classification", "labels": ["x"]}],
+            "splits": minimal_splits_dict(),
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertIn("train", di.splits)
+        self.assertIn("validation", di.splits)
+        self.assertIn("test", di.splits)
+
+    def test_missing_split_keys_raise(self):
+        payload = {
+            "task_templates": [{"task": "classification", "labels": ["x"]}],
+            "splits": {  # missing 'test'
+                "train": {"name": "train", "dataset_name": "a.json"},
+                "validation": {"name": "validation", "dataset_name": "b.json"},
+            },
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            DatasetInfo.parse_obj(payload)
+        self.assertIn("splits must include", str(ctx.exception))
+
+    def test_splits_must_be_mapping(self):
+        payload = {
+            "task_templates": [{"task": "classification", "labels": ["x"]}],
+            "splits": None,
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+        payload["splits"] = []  # not a mapping
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+    def test_splitinfo_required_fields_via_dict(self):
+        # Split missing required 'dataset_name'
+        payload = {
+            "task_templates": [{"task": "classification", "labels": ["x"]}],
+            "splits": {
+                "train": {"name": "train"},  # <-- missing dataset_name
+                "validation": {"name": "validation", "dataset_name": "b.json"},
+                "test": {"name": "test", "dataset_name": "c.json"},
+            },
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfo.parse_obj(payload)
+
+
+class TestFeaturesWithDicts(unittest.TestCase):
+    def test_features_optional_absent(self):
+        payload = {
+            "task_templates": [{"task": "classification", "labels": ["x"]}],
+            "splits": minimal_splits_dict(),
+            # no "features" key at all
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertIsNone(di.features)
+
+    def test_features_basic_image_sequence_dict(self):
+        payload = {
+            "task_templates": [{"task": "detection", "labels": ["person"]}],
+            "splits": minimal_splits_dict(),
+            "features": {
+                "image": {"_type": "Image", "id": None},
+                "labels": {"_type": "Sequence", "id": None},
+            },
+        }
+        di = DatasetInfo.parse_obj(payload)
+        self.assertEqual(di.features.image.type, "Image")
+        self.assertEqual(di.features.labels.type, "Sequence")
+
+    def test_features_nested_objects_like_samples(self):
+        payload = {
+            "task_templates": [{"task": "detection", "labels": ["person"]}],
+            "splits": minimal_splits_dict(),
+            "features": {
+                "image": {"_type": "Image"},
+                "labels": {"_type": "Sequence"},
+                "image/filename": {"_type": "Text"},  # extra key allowed? depends on your Features.Config
+                "objects": {
+                    "_type": "Sequence",
+                    "objects_bbox": {"_type": "BBoxFeature"},
+                    "objects_label": {"_type": "ClassLabel", "num_classes": 1, "names": ["person"]},
+                },
+            },
+        }
+        try:
+            di = DatasetInfo.parse_obj(payload)
+            self.assertEqual(di.features.image.type, "Image")
+        except ValidationError as e:
+            # If you disallow extras, assert that it does fail.
+            self.assertIsInstance(e, ValidationError)
+
+
+class TestDatasetInfosWithDicts(unittest.TestCase):
+    def mk_di_dict(self, task="classification"):
+        return {
+            "task_templates": [{"task": task, "labels": ["x"]}],
+            "splits": minimal_splits_dict(),
+        }
+
+    def test_parse_top_level_mapping(self):
+        data = {
+            "cats_dogs": self.mk_di_dict("classification"),
+            "people_det": self.mk_di_dict("detection"),
+        }
+        infos = DatasetInfos.parse_obj(data)
+        self.assertIn("cats_dogs", infos.__root__)
+        self.assertEqual(infos["people_det"].task_templates[0].task, "detection")
+
+    def test_parse_from_json_string(self):
+        data = {
+            "my_ds": self.mk_di_dict("classification")
+        }
+        json_str = json.dumps(data)
+        infos = DatasetInfos.parse_raw(json_str)
+        self.assertIn("my_ds", infos.__root__)
+
+    def test_datasetinfos_value_must_be_datasetinfo_shape(self):
+        bad = {
+            "ok_ds": self.mk_di_dict("classification"),
+            "bad_ds": {"not": "a DatasetInfo"},
+        }
+        with self.assertRaises(ValidationError):
+            DatasetInfos.parse_obj(bad)
+    
+    def test_load_sample_dataset_info_classification(self):
+        ds_path = osp.join(
+            _get_dataset_path(), "classification_sample"
+        )
+        datainfo_path = osp.join(ds_path, "dataset_infos.json")
+        with open(datainfo_path, 'r') as f:
+            di_dict = json.load(f)
+        di = DatasetInfos.parse_obj(di_dict)["classification_sample"]
+        self.assertEqual(di.task_templates[0].task, "classification")
+        self.assertIn("train", di.splits)
+        self.assertIn("validation", di.splits)
+        self.assertIn("test", di.splits)
+
+    def test_load_sample_dataset_info_object_detection(self):
+        ds_path = osp.join(
+            _get_dataset_path(), "objectdetection_sample"
+        )
+        datainfo_path = osp.join(ds_path, "dataset_infos.json")
+        with open(datainfo_path, 'r') as f:
+            di_dict = json.load(f)
+        di = DatasetInfos.parse_obj(di_dict)["objectdetection_sample"]
+        self.assertEqual(di.task_templates[0].task, "detection")
+        self.assertIn("train", di.splits)
+        self.assertIn("validation", di.splits)
+        self.assertIn("test", di.splits)
+
+    def test_load_sample_dataset_info_keypoint_detection(self):
+        ds_path = osp.join(
+            _get_dataset_path(), "keypoints_sample"
+        )
+        datainfo_path = osp.join(ds_path, "dataset_infos.json")
+        with open(datainfo_path, 'r') as f:
+            di_dict = json.load(f)
+        di = DatasetInfos.parse_obj(di_dict)["keypoints_sample"]
+        self.assertEqual(di.task_templates[0].task, "keypoints")
+        self.assertIn("train", di.splits)
+        self.assertIn("validation", di.splits)
+        self.assertIn("test", di.splits)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_datainfo_schema_validator.py
+++ b/tests/test_datainfo_schema_validator.py
@@ -32,9 +32,7 @@ def minimal_splits_dict():
 class TestTaskTemplateWithDicts(unittest.TestCase):
     def test_classification_minimal_dict(self):
         payload = {
-            "task_templates": [
-                {"task": "classification", "labels": ["cat", "dog"]}
-            ],
+            "task_templates": [{"task": "classification", "labels": ["cat", "dog"]}],
             "splits": minimal_splits_dict(),
         }
         di = DatasetInfo.parse_obj(payload)
@@ -43,9 +41,7 @@ class TestTaskTemplateWithDicts(unittest.TestCase):
 
     def test_detection_minimal_dict(self):
         payload = {
-            "task_templates": [
-                {"task": "detection", "labels": ["person"]}
-            ],
+            "task_templates": [{"task": "detection", "labels": ["person"]}],
             "splits": minimal_splits_dict(),
         }
         di = DatasetInfo.parse_obj(payload)
@@ -67,7 +63,11 @@ class TestTaskTemplateWithDicts(unittest.TestCase):
             with self.subTest(bad=bad):
                 payload = {
                     "task_templates": [
-                        {"task": "keypoints", "labels": ["person"], "num_keypoints": bad}
+                        {
+                            "task": "keypoints",
+                            "labels": ["person"],
+                            "num_keypoints": bad,
+                        }
                     ],
                     "splits": minimal_splits_dict(),
                 }
@@ -245,7 +245,11 @@ class TestFeaturesWithDicts(unittest.TestCase):
                 "objects": {
                     "_type": "Sequence",
                     "objects_bbox": {"_type": "BBoxFeature"},
-                    "objects_label": {"_type": "ClassLabel", "num_classes": 1, "names": ["person"]},
+                    "objects_label": {
+                        "_type": "ClassLabel",
+                        "num_classes": 1,
+                        "names": ["person"],
+                    },
                 },
             },
         }
@@ -270,9 +274,7 @@ class TestDatasetInfosWithDicts(unittest.TestCase):
         self.assertEqual(infos["people_det"].task_templates[0].task, "detection")
 
     def test_parse_from_json_string(self):
-        data = {
-            "my_ds": self.mk_di_dict("classification")
-        }
+        data = {"my_ds": self.mk_di_dict("classification")}
         json_str = json.dumps(data)
         infos = DatasetInfos.parse_raw(json_str)
         self.assertIn("my_ds", infos.__root__)
@@ -284,13 +286,11 @@ class TestDatasetInfosWithDicts(unittest.TestCase):
         }
         with self.assertRaises(ValidationError):
             DatasetInfos.parse_obj(bad)
-    
+
     def test_load_sample_dataset_info_classification(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "classification_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "classification_sample")
         datainfo_path = osp.join(ds_path, "dataset_infos.json")
-        with open(datainfo_path, 'r') as f:
+        with open(datainfo_path, "r") as f:
             di_dict = json.load(f)
         di = DatasetInfos.parse_obj(di_dict)["classification_sample"]
         self.assertEqual(di.task_templates[0].task, "classification")
@@ -299,11 +299,9 @@ class TestDatasetInfosWithDicts(unittest.TestCase):
         self.assertIn("test", di.splits)
 
     def test_load_sample_dataset_info_object_detection(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "objectdetection_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "objectdetection_sample")
         datainfo_path = osp.join(ds_path, "dataset_infos.json")
-        with open(datainfo_path, 'r') as f:
+        with open(datainfo_path, "r") as f:
             di_dict = json.load(f)
         di = DatasetInfos.parse_obj(di_dict)["objectdetection_sample"]
         self.assertEqual(di.task_templates[0].task, "detection")
@@ -312,11 +310,9 @@ class TestDatasetInfosWithDicts(unittest.TestCase):
         self.assertIn("test", di.splits)
 
     def test_load_sample_dataset_info_keypoint_detection(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "keypoints_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "keypoints_sample")
         datainfo_path = osp.join(ds_path, "dataset_infos.json")
-        with open(datainfo_path, 'r') as f:
+        with open(datainfo_path, "r") as f:
             di_dict = json.load(f)
         di = DatasetInfos.parse_obj(di_dict)["keypoints_sample"]
         self.assertEqual(di.task_templates[0].task, "keypoints")

--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -9,6 +9,6 @@ class TestPkg(unittest.TestCase):
         self.assertIsInstance(connector.__version__, str)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     log.getLogger().setLevel(log.INFO)
     unittest.main()

--- a/tests/test_sample_datasets.py
+++ b/tests/test_sample_datasets.py
@@ -14,16 +14,18 @@ from modelcat.connector.utils.misc import _get_dataset_path
 
 class TestSimple(unittest.TestCase):
     def test_classification(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "classification_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "classification_sample")
 
         with tempfile.TemporaryDirectory() as tmp:
             dsv = DatasetValidator(ds_path, tmp)
             msgs, _ = dsv.validate_dataset()
             log.info(msgs)
             # dataset copying causes change in dataset size of a few bytes
-            if len(msgs) == 1 and "size was calculated using the dataset root directory" in msgs[0]['message']:
+            if (
+                len(msgs) == 1
+                and "size was calculated using the dataset root directory"
+                in msgs[0]["message"]
+            ):
                 print("DEBUG")
                 msgs = []
             print(msgs)
@@ -31,40 +33,42 @@ class TestSimple(unittest.TestCase):
             self.assertEqual(len(msgs), 0)
 
     def test_object_detection(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "objectdetection_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "objectdetection_sample")
 
         with tempfile.TemporaryDirectory() as tmp:
             dsv = DatasetValidator(ds_path, tmp)
             msgs, _ = dsv.validate_dataset()
             log.info(msgs)
             # dataset copying causes change in dataset size of a few bytes
-            if len(msgs) == 1 and "size was calculated using the dataset root directory" in msgs[0]['message']:
+            if (
+                len(msgs) == 1
+                and "size was calculated using the dataset root directory"
+                in msgs[0]["message"]
+            ):
                 msgs = []
             # assert that there are not warning/error messages
             self.assertEqual(len(msgs), 0)
 
     def test_keypoint_detection(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "keypoints_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "keypoints_sample")
 
         with tempfile.TemporaryDirectory() as tmp:
             dsv = DatasetValidator(ds_path, tmp)
             msgs, _ = dsv.validate_dataset()
             log.info(msgs)
             # dataset copying causes change in dataset size of a few bytes
-            if len(msgs) == 1 and "size was calculated using the dataset root directory" in msgs[0]['message']:
+            if (
+                len(msgs) == 1
+                and "size was calculated using the dataset root directory"
+                in msgs[0]["message"]
+            ):
                 msgs = []
             # assert that there are not warning/error messages
             self.assertEqual(len(msgs), 0)
 
     # testing copying dataset to another directory, changing dataset infos entry and checking the autofix
     def test_autofix_simple(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "keypoints_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "keypoints_sample")
 
         with tempfile.TemporaryDirectory() as tmp:
             shutil.copytree(ds_path, tmp, dirs_exist_ok=True)
@@ -77,7 +81,7 @@ class TestSimple(unittest.TestCase):
             self.assertEqual(len(msgs), 0)
 
             # change dataset infos entry
-            with open(osp.join(tmp, 'dataset_infos.json')) as file:
+            with open(osp.join(tmp, "dataset_infos.json")) as file:
                 dataset_infos = json.load(file)
             dataset_name = list(dataset_infos.keys())[0]
             # scrambling dataset size
@@ -86,7 +90,7 @@ class TestSimple(unittest.TestCase):
             dataset_infos[dataset_name]["splits"]["train"]["num_bytes"] = 0
             # deleting an entry
             del dataset_infos[dataset_name]["builder_name"]
-            with open(osp.join(tmp, 'dataset_infos.json'), 'w') as file:
+            with open(osp.join(tmp, "dataset_infos.json"), "w") as file:
                 json.dump(dataset_infos, file)
             msgs, _ = dsv.validate_dataset()
             log.info(msgs)
@@ -94,20 +98,24 @@ class TestSimple(unittest.TestCase):
             self.assertEqual(len(msgs), 0)
 
     def test_autofix(self):
-        ds_path = osp.join(
-            _get_dataset_path(), "keypoints_sample"
-        )
+        ds_path = osp.join(_get_dataset_path(), "keypoints_sample")
 
         with tempfile.TemporaryDirectory() as tmp:
             shutil.copytree(ds_path, tmp, dirs_exist_ok=True)
             dsv_no_autofix = DatasetValidator(tmp, tmp, auto_fix=False)
-            dsv_autofix = DatasetValidator(tmp, tmp, auto_fix=True, auto_fix_2=UserChoice.YES)
+            dsv_autofix = DatasetValidator(
+                tmp, tmp, auto_fix=True, auto_fix_2=UserChoice.YES
+            )
             while True:
                 msgs, restart = dsv_no_autofix.validate_dataset()
                 if not restart:
                     break
             # assert that there are not warning/error messages (except potential dataset size on Mac)
-            if len(msgs) == 1 and "size was calculated using the dataset root directory" in msgs[0]['message']:
+            if (
+                len(msgs) == 1
+                and "size was calculated using the dataset root directory"
+                in msgs[0]["message"]
+            ):
                 msgs = []
             self.assertLessEqual(len(msgs), 1)
 
@@ -118,17 +126,19 @@ class TestSimple(unittest.TestCase):
                 coco_train = json.load(file)
             # image without annotations
             coco_train["annotations"] = [
-                ann for ann in coco_train["annotations"] if ann["image_id"] != coco_train["images"][0]["id"]
+                ann
+                for ann in coco_train["annotations"]
+                if ann["image_id"] != coco_train["images"][0]["id"]
             ]
             # duplicate images
             shutil.copy(
                 osp.join(images_dir, coco_train["images"][1]["file_name"]),
-                osp.join(images_dir, coco_train["images"][2]["file_name"])
+                osp.join(images_dir, coco_train["images"][2]["file_name"]),
             )
             # duplicate image filenames in the split
             coco_train["images"][3]["file_name"] = coco_train["images"][4]["file_name"]
 
-            with open(osp.join(annotations_dir, "coco_train.json"), 'w') as file:
+            with open(osp.join(annotations_dir, "coco_train.json"), "w") as file:
                 json.dump(coco_train, file)
 
             msgs, _ = dsv_no_autofix.validate_dataset()
@@ -145,6 +155,6 @@ class TestSimple(unittest.TestCase):
             self.assertEqual(len(msgs), 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     log.getLogger().setLevel(log.INFO)
     unittest.main()

--- a/tests/test_sample_datasets.py
+++ b/tests/test_sample_datasets.py
@@ -3,33 +3,12 @@
 # setup.py that excludes installing the "tests" package
 import shutil
 import unittest
-import modelcat.connector as connector
 from modelcat.connector.validate import DatasetValidator
 import os.path as osp
 import tempfile
 import logging as log
 import json
-import os
-
-
-def _get_dataset_path() -> str:
-    datasets_folder = 'sample_datasets'
-
-    # first try where package is installed
-    # this will work for local call of unittests
-    ds_path = osp.abspath(osp.join(osp.dirname(connector.__file__), "..", "..", "..", datasets_folder))
-    if osp.exists(ds_path):
-        print(ds_path)
-        return ds_path
-
-    # otherwise check current directory (this will work for tox)
-
-    ds_path = osp.abspath(osp.join(os.getcwd(), datasets_folder))
-    if osp.exists(ds_path):
-        print(ds_path)
-        return ds_path
-
-    raise FileExistsError(f'`{datasets_folder}` cannot be located')
+from modelcat.connector.utils.misc import _get_dataset_path
 
 
 class TestSimple(unittest.TestCase):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -7,21 +7,28 @@ from modelcat.connector.setup import run_setup, setup_cli
 class TestSetup(unittest.TestCase):
     """Test cases for the setup module."""
 
-    @patch('modelcat.connector.setup.check_awscli')
-    @patch('modelcat.connector.setup.input')
-    @patch('modelcat.connector.setup.getpass')
-    @patch('modelcat.connector.setup.ProductAPIClient')
-    @patch('modelcat.connector.setup.check_aws_configuration')
-    @patch('modelcat.connector.setup.os.makedirs')
-    @patch('modelcat.connector.setup.os.path.exists')
-    @patch('modelcat.connector.setup.Path.home')
+    @patch("modelcat.connector.setup.check_awscli")
+    @patch("modelcat.connector.setup.input")
+    @patch("modelcat.connector.setup.getpass")
+    @patch("modelcat.connector.setup.ProductAPIClient")
+    @patch("modelcat.connector.setup.check_aws_configuration")
+    @patch("modelcat.connector.setup.os.makedirs")
+    @patch("modelcat.connector.setup.os.path.exists")
+    @patch("modelcat.connector.setup.Path.home")
     def test_run_setup_success(
-            self, mock_home, mock_path_exists, mock_makedirs, mock_check_aws_config,
-            mock_api_client, mock_getpass, mock_input, mock_check_awscli
+        self,
+        mock_home,
+        mock_path_exists,
+        mock_makedirs,
+        mock_check_aws_config,
+        mock_api_client,
+        mock_getpass,
+        mock_input,
+        mock_check_awscli,
     ):
         """Test a successful setup process."""
         # Mock home directory
-        mock_home.return_value = '/mock/home'
+        mock_home.return_value = "/mock/home"
 
         # Mock path exists to return False (no existing config)
         mock_path_exists.return_value = False
@@ -35,12 +42,10 @@ class TestSetup(unittest.TestCase):
 
         # Mock ProductAPIClient
         mock_client_instance = MagicMock()
-        mock_client_instance.get_me.return_value = {
-            "full_name": "Test User"
-        }
+        mock_client_instance.get_me.return_value = {"full_name": "Test User"}
         mock_client_instance.get_aws_access.return_value = {
             "access_key_id": "mock_access_key",
-            "secret_access_key": "mock_secret_key"
+            "secret_access_key": "mock_secret_key",
         }
         mock_api_client.return_value = mock_client_instance
 
@@ -48,7 +53,7 @@ class TestSetup(unittest.TestCase):
         mock_check_aws_config.return_value = True
 
         # Run the setup function with mocked open
-        with patch('builtins.open', mock_open()) as mock_file:
+        with patch("builtins.open", mock_open()) as mock_file:
             run_setup()
 
         # Verify AWS CLI was checked
@@ -72,14 +77,16 @@ class TestSetup(unittest.TestCase):
         # The write method is called multiple times to write the JSON config file
         self.assertTrue(mock_file().write.called)
 
-    @patch('modelcat.connector.setup.check_awscli')
-    @patch('modelcat.connector.setup.os.makedirs')
-    @patch('modelcat.connector.setup.os.path.exists')
-    @patch('modelcat.connector.setup.Path.home')
-    def test_run_setup_no_aws_cli(self, mock_home, mock_path_exists, mock_makedirs, mock_check_awscli):
+    @patch("modelcat.connector.setup.check_awscli")
+    @patch("modelcat.connector.setup.os.makedirs")
+    @patch("modelcat.connector.setup.os.path.exists")
+    @patch("modelcat.connector.setup.Path.home")
+    def test_run_setup_no_aws_cli(
+        self, mock_home, mock_path_exists, mock_makedirs, mock_check_awscli
+    ):
         """Test setup process when AWS CLI is not installed."""
         # Mock home directory
-        mock_home.return_value = '/mock/home'
+        mock_home.return_value = "/mock/home"
 
         # Mock path exists to return False (no existing config)
         mock_path_exists.return_value = False
@@ -88,7 +95,7 @@ class TestSetup(unittest.TestCase):
         mock_check_awscli.return_value = False
 
         # Run the setup function with exit expected
-        with patch('builtins.open', mock_open()):
+        with patch("builtins.open", mock_open()):
             with self.assertRaises(SystemExit) as cm:
                 run_setup()
 
@@ -98,8 +105,8 @@ class TestSetup(unittest.TestCase):
         # Verify AWS CLI was checked
         mock_check_awscli.assert_called_once()
 
-    @patch('modelcat.connector.setup.run_setup')
-    @patch('argparse.ArgumentParser.parse_args')
+    @patch("modelcat.connector.setup.run_setup")
+    @patch("argparse.ArgumentParser.parse_args")
     def test_setup_cli(self, mock_parse_args, mock_run_setup):
         """Test the setup_cli function."""
         # Mock the parse_args method to return a namespace with debug=False
@@ -113,17 +120,26 @@ class TestSetup(unittest.TestCase):
         # Verify run_setup was called with verbose=0
         mock_run_setup.assert_called_once_with(verbose=0)
 
-    @patch('modelcat.connector.setup.check_awscli')
-    @patch('modelcat.connector.setup.input')
-    @patch('modelcat.connector.setup.getpass')
-    @patch('modelcat.connector.setup.ProductAPIClient')
-    @patch('modelcat.connector.setup.os.makedirs')
-    @patch('modelcat.connector.setup.os.path.exists')
-    @patch('modelcat.connector.setup.Path.home')
-    def test_run_setup_api_error(self, mock_home, mock_path_exists, mock_makedirs, mock_api_client, mock_getpass, mock_input, mock_check_awscli):
+    @patch("modelcat.connector.setup.check_awscli")
+    @patch("modelcat.connector.setup.input")
+    @patch("modelcat.connector.setup.getpass")
+    @patch("modelcat.connector.setup.ProductAPIClient")
+    @patch("modelcat.connector.setup.os.makedirs")
+    @patch("modelcat.connector.setup.os.path.exists")
+    @patch("modelcat.connector.setup.Path.home")
+    def test_run_setup_api_error(
+        self,
+        mock_home,
+        mock_path_exists,
+        mock_makedirs,
+        mock_api_client,
+        mock_getpass,
+        mock_input,
+        mock_check_awscli,
+    ):
         """Test setup process when API returns an error."""
         # Mock home directory
-        mock_home.return_value = '/mock/home'
+        mock_home.return_value = "/mock/home"
 
         # Mock path exists to return False (no existing config)
         mock_path_exists.return_value = False
@@ -137,12 +153,13 @@ class TestSetup(unittest.TestCase):
 
         # Mock ProductAPIClient to raise an APIError
         from modelcat.connector.utils.api import APIError
+
         mock_client_instance = MagicMock()
         mock_client_instance.get_me.side_effect = APIError("API Error")
         mock_api_client.return_value = mock_client_instance
 
         # Run the setup function with exit expected
-        with patch('builtins.open', mock_open()):
+        with patch("builtins.open", mock_open()):
             with self.assertRaises(SystemExit) as cm:
                 run_setup()
 
@@ -150,5 +167,5 @@ class TestSetup(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -21,15 +21,11 @@ class TestDatasetUploader(unittest.TestCase):
                 "license": "",
                 "features": {},
                 "splits": {
-                    "train": {
-                        "name": "train",
-                        "num_bytes": 1000,
-                        "num_examples": 10
-                    }
+                    "train": {"name": "train", "num_bytes": 1000, "num_examples": 10}
                 },
                 "supervised_keys": None,
                 "builder_name": "test_builder",
-                "dataset_size": 5000
+                "dataset_size": 5000,
             }
         }
 
@@ -38,30 +34,42 @@ class TestDatasetUploader(unittest.TestCase):
         self.group_id = "12345678-1234-1234-1234-123456789012"
         self.oauth_token = "1_1234567890abcdef1234567890abcdef12345678"
 
-    @patch('modelcat.connector.upload.check_aws_configuration')
-    @patch('modelcat.connector.upload.osp.exists')
-    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps({"test_dataset": {
-        "description": "Test dataset",
-        "citation": "",
-        "homepage": "",
-        "license": "",
-        "features": {},
-        "splits": {
-            "train": {
-                "name": "train",
-                "num_bytes": 1000,
-                "num_examples": 10
+    @patch("modelcat.connector.upload.check_aws_configuration")
+    @patch("modelcat.connector.upload.osp.exists")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=json.dumps(
+            {
+                "test_dataset": {
+                    "description": "Test dataset",
+                    "citation": "",
+                    "homepage": "",
+                    "license": "",
+                    "features": {},
+                    "splits": {
+                        "train": {
+                            "name": "train",
+                            "num_bytes": 1000,
+                            "num_examples": 10,
+                        }
+                    },
+                    "supervised_keys": None,
+                    "builder_name": "test_builder",
+                    "dataset_size": 5000,
+                }
             }
-        },
-        "supervised_keys": None,
-        "builder_name": "test_builder",
-        "dataset_size": 5000
-    }}))
-    @patch('modelcat.connector.upload.check_s3_access')
-    @patch('modelcat.connector.upload.DatasetUploader.dataset_check')
+        ),
+    )
+    @patch("modelcat.connector.upload.check_s3_access")
+    @patch("modelcat.connector.upload.DatasetUploader.dataset_check")
     def test_init_success(
-            self, mock_dataset_check, mock_check_s3_access,
-            mock_open, mock_exists, mock_check_aws_config
+        self,
+        mock_dataset_check,
+        mock_check_s3_access,
+        mock_open,
+        mock_exists,
+        mock_check_aws_config,
     ):
         """Test successful initialization of DatasetUploader."""
         # Mock dependencies
@@ -74,7 +82,7 @@ class TestDatasetUploader(unittest.TestCase):
             dataset_root_dir=self.dataset_root,
             working_dir=self.dataset_root,
             group_id=self.group_id,
-            oauth_token=self.oauth_token
+            oauth_token=self.oauth_token,
         )
 
         # Verify initialization
@@ -82,15 +90,18 @@ class TestDatasetUploader(unittest.TestCase):
         self.assertEqual(uploader.group_id, self.group_id)
         self.assertEqual(uploader.oauth_token, self.oauth_token)
         self.assertEqual(uploader.dataset_name, "test_dataset")
-        self.assertIn(f"s3://{PRODUCT_S3_BUCKET}/account/{self.group_id}/datasets/", uploader.s3_uri)
+        self.assertIn(
+            f"s3://{PRODUCT_S3_BUCKET}/account/{self.group_id}/datasets/",
+            uploader.s3_uri,
+        )
 
         # Verify dependencies were checked
         mock_check_aws_config.assert_called_once()
         mock_exists.assert_called_once_with(self.dataset_root)
         mock_dataset_check.assert_called_once()
 
-    @patch('modelcat.connector.upload.check_aws_configuration')
-    @patch('modelcat.connector.upload.osp.exists')
+    @patch("modelcat.connector.upload.check_aws_configuration")
+    @patch("modelcat.connector.upload.osp.exists")
     def test_init_invalid_uuid(self, mock_exists, mock_check_aws_config):
         """Test initialization with invalid UUID."""
         # Mock dependencies
@@ -103,14 +114,14 @@ class TestDatasetUploader(unittest.TestCase):
                 dataset_root_dir=self.dataset_root,
                 working_dir=self.dataset_root,
                 group_id="invalid-uuid",
-                oauth_token=self.oauth_token
+                oauth_token=self.oauth_token,
             )
 
         # Verify exit code
         self.assertEqual(cm.exception.code, 1)
 
-    @patch('modelcat.connector.upload.check_aws_configuration')
-    @patch('modelcat.connector.upload.osp.exists')
+    @patch("modelcat.connector.upload.check_aws_configuration")
+    @patch("modelcat.connector.upload.osp.exists")
     def test_init_path_not_exists(self, mock_exists, mock_check_aws_config):
         """Test initialization with non-existent path."""
         # Mock dependencies
@@ -123,40 +134,50 @@ class TestDatasetUploader(unittest.TestCase):
                 dataset_root_dir=self.dataset_root,
                 working_dir=self.dataset_root,
                 group_id=self.group_id,
-                oauth_token=self.oauth_token
+                oauth_token=self.oauth_token,
             )
 
         # Verify exit code
         self.assertEqual(cm.exception.code, 1)
 
-    @patch('modelcat.connector.upload.osp.exists', return_value=True)
-    @patch('modelcat.connector.upload.hash_dataset', return_value="test_sha_hash")
-    @patch('modelcat.connector.upload.check_aws_configuration', return_value=True)
-    @patch('modelcat.connector.upload.check_s3_access')
-    def test_dataset_check_success(self, mock_check_s3_access, mock_check_aws_config, mock_hash_dataset, mock_exists):
+    @patch("modelcat.connector.upload.osp.exists", return_value=True)
+    @patch("modelcat.connector.upload.hash_dataset", return_value="test_sha_hash")
+    @patch("modelcat.connector.upload.check_aws_configuration", return_value=True)
+    @patch("modelcat.connector.upload.check_s3_access")
+    def test_dataset_check_success(
+        self,
+        mock_check_s3_access,
+        mock_check_aws_config,
+        mock_hash_dataset,
+        mock_exists,
+    ):
         """Test successful dataset check."""
         # Skip the actual dataset_check in the constructor
-        with patch.object(DatasetUploader, 'dataset_check', return_value=True):
+        with patch.object(DatasetUploader, "dataset_check", return_value=True):
             # Mock the file operations
-            dataset_infos_mock = mock_open(read_data=json.dumps(self.mock_dataset_infos))
-            validator_log_mock = mock_open(read_data="Validation passed and signed: test_sha_hash")
+            dataset_infos_mock = mock_open(
+                read_data=json.dumps(self.mock_dataset_infos)
+            )
+            validator_log_mock = mock_open(
+                read_data="Validation passed and signed: test_sha_hash"
+            )
 
             # Create a side_effect function that returns different mock objects based on the file path
             def open_side_effect(file, *args, **kwargs):
-                if 'dataset_infos.json' in str(file):
+                if "dataset_infos.json" in str(file):
                     return dataset_infos_mock()
-                elif 'dataset_validator_log.txt' in str(file):
+                elif "dataset_validator_log.txt" in str(file):
                     return validator_log_mock()
                 return mock_open().return_value
 
             # Apply the mock with side_effect
-            with patch('builtins.open', side_effect=open_side_effect):
+            with patch("builtins.open", side_effect=open_side_effect):
                 # Create the uploader instance
                 uploader = DatasetUploader(
                     dataset_root_dir=self.dataset_root,
                     working_dir=self.dataset_root,
                     group_id=self.group_id,
-                    oauth_token=self.oauth_token
+                    oauth_token=self.oauth_token,
                 )
 
                 # Override the mocked dataset_check to test the actual method
@@ -171,17 +192,29 @@ class TestDatasetUploader(unittest.TestCase):
                 # hash_dataset is not called in dataset_check when validator_log exists
                 # and contains a valid signature, so we don't assert it here
 
-    @patch('modelcat.connector.upload.run_cli_command')
-    @patch('modelcat.connector.upload.ProductAPIClient')
-    @patch('modelcat.connector.upload.DatasetUploader.dataset_check', return_value=True)
-    @patch('modelcat.connector.upload.DatasetUploader.obtain_s3_access', return_value=None)
-    @patch('modelcat.connector.upload.check_aws_configuration', return_value=True)
-    @patch('modelcat.connector.upload.osp.exists', return_value=True)
-    @patch('modelcat.connector.upload.check_s3_access')
-    @patch('modelcat.connector.upload.DatasetUploader._count_files', return_value=(10, 1000))
+    @patch("modelcat.connector.upload.run_cli_command")
+    @patch("modelcat.connector.upload.ProductAPIClient")
+    @patch("modelcat.connector.upload.DatasetUploader.dataset_check", return_value=True)
+    @patch(
+        "modelcat.connector.upload.DatasetUploader.obtain_s3_access", return_value=None
+    )
+    @patch("modelcat.connector.upload.check_aws_configuration", return_value=True)
+    @patch("modelcat.connector.upload.osp.exists", return_value=True)
+    @patch("modelcat.connector.upload.check_s3_access")
+    @patch(
+        "modelcat.connector.upload.DatasetUploader._count_files",
+        return_value=(10, 1000),
+    )
     def test_upload_s3_success(
-            self, mock_count_files, mock_check_s3_access, mock_exists,
-            mock_check_aws_config, mock_obtain_s3_access, mock_dataset_check, mock_api_client, mock_run_cli
+        self,
+        mock_count_files,
+        mock_check_s3_access,
+        mock_exists,
+        mock_check_aws_config,
+        mock_obtain_s3_access,
+        mock_dataset_check,
+        mock_api_client,
+        mock_run_cli,
     ):
         """Test successful S3 upload."""
         # Mock dependencies
@@ -189,7 +222,7 @@ class TestDatasetUploader(unittest.TestCase):
         mock_client_instance.register_dataset.return_value = {"uuid": "test-uuid"}
         mock_client_instance.submit_dataset_analysis.return_value = {
             "uuid": "test-uuid",
-            "results_url": "/results?uuid=test-uuid"
+            "results_url": "/results?uuid=test-uuid",
         }
         mock_api_client.return_value = mock_client_instance
 
@@ -197,13 +230,13 @@ class TestDatasetUploader(unittest.TestCase):
         dataset_infos_mock = mock_open(read_data=json.dumps(self.mock_dataset_infos))
 
         # Apply the mock with side_effect
-        with patch('builtins.open', return_value=dataset_infos_mock()):
+        with patch("builtins.open", return_value=dataset_infos_mock()):
             # Create uploader instance
             uploader = DatasetUploader(
                 dataset_root_dir=self.dataset_root,
                 working_dir=self.dataset_root,
                 group_id=self.group_id,
-                oauth_token=self.oauth_token
+                oauth_token=self.oauth_token,
             )
 
             # Run the upload
@@ -215,21 +248,27 @@ class TestDatasetUploader(unittest.TestCase):
         # Verify API client was created and used
         mock_api_client.assert_called_once()
         mock_client_instance.register_dataset.assert_called_once_with(
-            name="test_dataset",
-            s3_uri=ANY,
-            dataset_infos=self.mock_dataset_infos
+            name="test_dataset", s3_uri=ANY, dataset_infos=self.mock_dataset_infos
         )
         mock_client_instance.submit_dataset_analysis.assert_called_once()
 
-    @patch('modelcat.connector.upload.argparse.ArgumentParser.parse_args')
-    @patch('modelcat.connector.utils.common.resolve_version', return_value="1.0.0")
-    @patch('modelcat.connector.upload.osp.join')
-    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps({
-        "group_id": "12345678-1234-1234-1234-123456789012",
-        "oauth_token": "1_1234567890abcdef1234567890abcdef12345678"
-    }))
-    @patch('modelcat.connector.upload.DatasetUploader')
-    def test_upload_cli(self, mock_uploader, mock_file, mock_join, mock_get_dist, mock_parse_args):
+    @patch("modelcat.connector.upload.argparse.ArgumentParser.parse_args")
+    @patch("modelcat.connector.utils.common.resolve_version", return_value="1.0.0")
+    @patch("modelcat.connector.upload.osp.join")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=json.dumps(
+            {
+                "group_id": "12345678-1234-1234-1234-123456789012",
+                "oauth_token": "1_1234567890abcdef1234567890abcdef12345678",
+            }
+        ),
+    )
+    @patch("modelcat.connector.upload.DatasetUploader")
+    def test_upload_cli(
+        self, mock_uploader, mock_file, mock_join, mock_get_dist, mock_parse_args
+    ):
         """Test the upload_cli function."""
         # Mock command line arguments
         args = MagicMock()
@@ -265,5 +304,5 @@ class TestDatasetUploader(unittest.TestCase):
         mock_uploader_instance.upload_s3.assert_called_once()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,6 @@ commands =
 
 [flake8]
 per-file-ignores = __init__.py:F401
-extend-ignore = E501
+extend-ignore = E501, W503
 exclude = .tox,*.egg,build,data,*venv*
 select = E,W,F


### PR DESCRIPTION
Added pydantic-based validators for `dataset_infos.json` and annotation files `coco_*.json` .
Added unittests for failure and success cases.

Closes: https://etacompute.atlassian.net/browse/BOOM-3575