### PR TITLE
Vaidate Category has at least one Sample

### DIFF
--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -5,7 +5,7 @@ import logging as log
 import os.path as osp
 import os
 import math
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from itertools import combinations
 from collections import Counter
 import shutil
@@ -438,6 +438,9 @@ class DatasetValidator:
                     }
                 )
 
+            m = self.check_categories_have_annotations(coco, coco_file_name)
+            messages.extend(m)
+
             missing_images = []
             imgs_without_anns = []
 
@@ -574,6 +577,49 @@ class DatasetValidator:
                 }
             )
 
+        return messages
+    
+    def check_categories_have_annotations(
+        self,
+        coco: Dict[str, Any],
+        coco_file_name: Optional[str] = "",
+    ) -> List[Dict[str, str]]:
+        """
+        Validate that every category in coco["categories"] has at least one annotation in coco["annotations"].
+        Returns a list of message dicts (type/message).
+        """
+        messages: List[Dict[str, str]] = []
+
+        categories = coco.get("categories", [])
+        annotations = coco.get("annotations", [])
+
+        category_ids = [cat.get("id") for cat in categories if "id" in cat]
+        cat_id_to_name = {cat["id"]: cat.get("name", str(cat["id"])) for cat in categories if "id" in cat}
+
+        # only count annotations that reference valid categories (avoid noise if file is malformed)
+        valid_category_ids = set(category_ids)
+        ann_cat_ids = [
+            ann.get("category_id")
+            for ann in annotations
+            if ann.get("category_id") in valid_category_ids
+        ]
+
+        cat_counts = Counter(ann_cat_ids)
+
+        missing_cat_ids = [cid for cid in category_ids if cat_counts.get(cid, 0) == 0]
+        if not missing_cat_ids:
+            return messages
+
+        missing_cat_names = [cat_id_to_name.get(cid, str(cid)) for cid in missing_cat_ids]
+        messages.append(
+            {
+                "type": "error",
+                "message": (
+                    f'The annotation file "{coco_file_name}" contains categories with no images: '
+                    f"{missing_cat_names}. Ensure each category has at least one annotated instance or remove the category."
+                ),
+            }
+        )
         return messages
 
     def check_for_duplicate_images(self, coco_path: str):

--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -432,7 +432,19 @@ class DatasetValidator:
         if not annotations_required:
             return []
 
-        for ann_file in ann_file_names:
+        if len(ann_file_names) != len(split_names):
+            messages.append(
+                {
+                    "type": "error",
+                    "message": (
+                        'The number of "annotation_files" does not match the number of '
+                        '"split_names" in "dataset_infos.json".'
+                    ),
+                }
+            )
+            return messages
+
+        for ann_file, split_name in zip(ann_file_names, split_names):
             if not osp.exists(osp.join(self.ann_dir, ann_file)):
                 messages.append(
                     {
@@ -443,7 +455,7 @@ class DatasetValidator:
                 )
             else:
                 messages += self.validate_coco_file(
-                    osp.join(self.ann_dir, ann_file), label_names
+                    osp.join(self.ann_dir, ann_file), split_name, label_names
                 )
 
         for ann_file in ann_file_names:
@@ -466,7 +478,7 @@ class DatasetValidator:
             )
         return messages
 
-    def validate_coco_file(self, coco_file_path: str, label_names: List[str]):
+    def validate_coco_file(self, coco_file_path: str, split_name: str, label_names: List[str]):
         messages = []
         coco_file_name = osp.basename(coco_file_path)
 
@@ -496,7 +508,7 @@ class DatasetValidator:
                     }
                 )
 
-            m = self.check_categories_have_annotations(coco, coco_file_name)
+            m = self.check_categories_have_annotations(coco, coco_file_name, split_name)
             messages.extend(m)
 
             missing_images = []
@@ -666,6 +678,7 @@ class DatasetValidator:
         self,
         coco: Dict[str, Any],
         coco_file_name: Optional[str] = "",
+        split_name: Optional[str] = "",
     ) -> List[Dict[str, str]]:
         """
         Validate that every category in coco["categories"] has at least one annotation in coco["annotations"].
@@ -694,11 +707,17 @@ class DatasetValidator:
             return messages
 
         missing_cat_names = [cat_id_to_name.get(cid, str(cid)) for cid in missing_cat_ids]
+
+        if split_name.lower() == "train":
+            message_type = "error"
+        else:
+            message_type = "warning"
+
         messages.append(
             {
-                "type": "error",
+                "type": message_type,
                 "message": (
-                    f'The annotation file "{coco_file_name}" contains categories with no images: '
+                    f'The annotation file "{coco_file_name}" in split "{split_name}" contains categories with no images: '
                     f"{missing_cat_names}. Ensure each category has at least one annotated instance or remove the category."
                 ),
             }

--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -661,7 +661,7 @@ class DatasetValidator:
             )
 
         return messages
-    
+
     def check_categories_have_annotations(
         self,
         coco: Dict[str, Any],


### PR DESCRIPTION
Category that do not have any samples are meaningless and should be removed from category list in annotation files.

This PR will raise error if any category doesn't have at least one sample (for train set) and warning for others. Example:

```
-------------------------------------------- Messages: ---------------------------------------------
WARNING: "dataset_infos.json" shows 769947B as dataset size, but 740339 B size was calculated using the dataset root directory.
ERROR: The annotation file "coco_train.json" contains categories with no images: ['horse']. Ensure each category has at least one annotated instance or remove the category.
WARNING: The annotation file "coco_validation.json" contains categories with no images: ['horse']. Ensure each category has at least one annotated instance or remove the category.
WARNING: The annotation file "coco_test.json" contains categories with no images: ['horse']. Ensure each category has at least one annotated instance or remove the category.
```

Closes: https://etacompute.atlassian.net/browse/BOOM-3970