### PR TITLE
feature: added modelcat_fetch CLI utility for robust Roboflow dataset conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ test = ["coverage"]
 modelcat_validate  = "modelcat.connector.validate:validate_cli"
 modelcat_upload    = "modelcat.connector.upload:upload_cli"
 modelcat_setup     = "modelcat.connector.setup:setup_cli"
+modelcat_fetch     = "modelcat.connector.fetch:fetch_cli"
 
 # This is configuration specific to the `setuptools` build backend.
 # If you are using a different build backend, you will need to change this.

--- a/src/modelcat/connector/fetch.py
+++ b/src/modelcat/connector/fetch.py
@@ -11,6 +11,7 @@ from os import environ
 # Setup logging
 log.basicConfig(format="%(levelname)s: %(message)s", level=log.INFO)
 
+
 def ensure_dependencies():
     """Checks for required dependencies and installs them if missing."""
     required_packages = {
@@ -18,7 +19,11 @@ def ensure_dependencies():
         "dotenv": "python-dotenv",
         "requests": "requests",
     }
-    missing = [pkg for mod, pkg in required_packages.items() if not __import__('importlib.util').util.find_spec(mod)]
+    missing = [
+        pkg
+        for mod, pkg in required_packages.items()
+        if not __import__("importlib.util").util.find_spec(mod)
+    ]
     if missing:
         log.info(f"Installing missing dependencies: {', '.join(missing)}...")
         try:
@@ -27,20 +32,25 @@ def ensure_dependencies():
             log.error(f"Failed to install dependencies: {e}")
             sys.exit(1)
 
+
 def parse_roboflow_url(url: str):
     """Extracts workspace, project, and version from a Roboflow Universe URL."""
     pattern = r"universe\.roboflow\.com/([^/]+)/([^/]+)(?:/(?:dataset|model)/)?(\d+)?"
     match = re.search(pattern, url)
     if not match:
-        raise ValueError("Invalid Roboflow Universe URL. Expected format: https://universe.roboflow.com/<workspace>/<project>[/version]")
-    
+        raise ValueError(
+            "Invalid Roboflow Universe URL. Expected format: https://universe.roboflow.com/<workspace>/<project>[/version]"
+        )
+
     workspace, project, version = match.groups()
     return workspace, project, int(version) if version else None
+
 
 def get_api_key():
     """Fetches the API key from .env or prompts the user interactively."""
     try:
         from dotenv import load_dotenv
+
         load_dotenv()
     except ImportError:
         pass
@@ -48,18 +58,21 @@ def get_api_key():
     api_key = environ.get("ROBOFLOW_API_KEY")
     if not api_key:
         print("\nRoboflow API key not found in .env.")
-        print("You can get your API key from https://app.roboflow.com/ -> Settings -> API Keys")
+        print(
+            "You can get your API key from https://app.roboflow.com/ -> Settings -> API Keys"
+        )
         api_key = input("Enter your Roboflow API Key: ").strip()
         if not api_key:
             log.error("API Key is required to fetch datasets.")
             sys.exit(1)
-        
+
         save = input("Save this key to .env for future use? (y/n): ").strip().lower()
-        if save == 'y':
+        if save == "y":
             with open(".env", "a") as f:
                 f.write(f"\nROBOFLOW_API_KEY={api_key}\n")
             log.info("API Key saved to .env")
     return api_key
+
 
 def clean_supercategories(base_dir):
     """Removes supercategories and empty classes."""
@@ -88,7 +101,8 @@ def clean_supercategories(base_dir):
     category_info = {}
 
     for data in anns_by_split.values():
-        if not data: continue
+        if not data:
+            continue
         for cat in data.get("categories", []):
             cat_id = cat["id"]
             sc = cat.get("supercategory", "none")
@@ -98,7 +112,8 @@ def clean_supercategories(base_dir):
                 category_counts[cat_id] = 0
 
     for data in anns_by_split.values():
-        if not data: continue
+        if not data:
+            continue
         for ann in data.get("annotations", []):
             cat_id = ann["category_id"]
             if cat_id in category_counts:
@@ -108,7 +123,8 @@ def clean_supercategories(base_dir):
     id_map = {old_id: new_idx for new_idx, old_id in enumerate(kept_ids)}
 
     for split, data in anns_by_split.items():
-        if not data: continue
+        if not data:
+            continue
         new_categories = []
         for cat in data.get("categories", []):
             if cat["id"] in id_map:
@@ -129,6 +145,7 @@ def clean_supercategories(base_dir):
         with open(os.path.join(base_dir, split, "_annotations.coco.json"), "w") as f:
             json.dump(data, f)
 
+
 def format_for_modelcat(rf_dir, dest_dir, project_name):
     """Restructures Roboflow export to ModelCat standard."""
     log.info("Converting dataset to ModelCat format...")
@@ -137,7 +154,12 @@ def format_for_modelcat(rf_dir, dest_dir, project_name):
     os.makedirs(os.path.join(dest_dir, "images"), exist_ok=True)
 
     # Map all Roboflow variations to ModelCat splits
-    rf_splits = {"train": "train", "valid": "validation", "val": "validation", "test": "test"}
+    rf_splits = {
+        "train": "train",
+        "valid": "validation",
+        "val": "validation",
+        "test": "test",
+    }
     rf_license = None
 
     for rf_split, mc_split in rf_splits.items():
@@ -147,13 +169,15 @@ def format_for_modelcat(rf_dir, dest_dir, project_name):
 
         mc_img_dir = os.path.join(dest_dir, "images", mc_split)
         if not os.path.exists(mc_img_dir):
-            shutil.copytree(src_split_dir, mc_img_dir, ignore=shutil.ignore_patterns("*.json"))
+            shutil.copytree(
+                src_split_dir, mc_img_dir, ignore=shutil.ignore_patterns("*.json")
+            )
 
         ann_path = os.path.join(src_split_dir, "_annotations.coco.json")
         if os.path.exists(ann_path):
             with open(ann_path, "r") as f:
                 coco_data = json.load(f)
-            
+
             if not rf_license and coco_data.get("licenses"):
                 rf_license = coco_data["licenses"][0]
 
@@ -164,18 +188,25 @@ def format_for_modelcat(rf_dir, dest_dir, project_name):
             for annotation in coco_data.get("annotations", []):
                 annotation["category_id"] += 1
 
-            dest_ann_path = os.path.join(dest_dir, "annotations", f"coco_{mc_split}.json")
+            dest_ann_path = os.path.join(
+                dest_dir, "annotations", f"coco_{mc_split}.json"
+            )
             with open(dest_ann_path, "w") as f:
                 json.dump(coco_data, f)
 
     return rf_license
 
+
 def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detection"):
     """Generates the metadata JSON required by ModelCat."""
-    license_name = rf_license.get('name', 'Unknown') if rf_license else 'Unknown'
-    
-    if license_name and any(x in license_name.upper() for x in ["NC", "NON-COMMERCIAL", "GPL"]):
-        log.warning(f"ATTENTION: Dataset has a strictly commercial or restrictive license: {license_name}")
+    license_name = rf_license.get("name", "Unknown") if rf_license else "Unknown"
+
+    if license_name and any(
+        x in license_name.upper() for x in ["NC", "NON-COMMERCIAL", "GPL"]
+    ):
+        log.warning(
+            f"ATTENTION: Dataset has a strictly commercial or restrictive license: {license_name}"
+        )
 
     class_names = []
     for split in ["train", "validation", "test"]:
@@ -183,41 +214,58 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
         if os.path.exists(ann_path):
             with open(ann_path) as f:
                 coco_data = json.load(f)
-                class_names = [c["name"] for c in sorted(coco_data.get("categories", []), key=lambda x: x["id"])]
+                class_names = [
+                    c["name"]
+                    for c in sorted(
+                        coco_data.get("categories", []), key=lambda x: x["id"]
+                    )
+                ]
                 break
 
     splits = {}
     total_imgs, total_bytes = 0, 0
-    
+
     for split in ["train", "validation", "test"]:
         img_dir = os.path.join(dest_dir, "images", split)
         ann_path = os.path.join(dest_dir, "annotations", f"coco_{split}.json")
-        
-        if os.path.exists(img_dir) and os.path.exists(ann_path) and len(os.listdir(img_dir)) > 0:
+
+        if (
+            os.path.exists(img_dir)
+            and os.path.exists(ann_path)
+            and len(os.listdir(img_dir)) > 0
+        ):
             num_imgs = len(os.listdir(img_dir))
-            num_bytes = sum(os.path.getsize(os.path.join(img_dir, f)) for f in os.listdir(img_dir))
+            num_bytes = sum(
+                os.path.getsize(os.path.join(img_dir, f)) for f in os.listdir(img_dir)
+            )
             splits[split] = {
                 "name": split,
                 "num_bytes": num_bytes,
                 "num_examples": num_imgs,
-                "dataset_name": f"coco_{split}.json"
+                "dataset_name": f"coco_{split}.json",
             }
             total_imgs += num_imgs
             total_bytes += num_bytes
         else:
-            empty_coco = {"info": {}, "licenses": [], "images": [], "annotations": [], "categories": []}
+            empty_coco = {
+                "info": {},
+                "licenses": [],
+                "images": [],
+                "annotations": [],
+                "categories": [],
+            }
             os.makedirs(os.path.join(dest_dir, "annotations"), exist_ok=True)
             os.makedirs(os.path.join(dest_dir, "images", split), exist_ok=True)
-            
+
             empty_ann_path = os.path.join(dest_dir, "annotations", f"coco_{split}.json")
             with open(empty_ann_path, "w") as f:
                 json.dump(empty_coco, f)
-            
+
             splits[split] = {
                 "name": split,
                 "num_bytes": 0,
                 "num_examples": 0,
-                "dataset_name": f"coco_{split}.json"
+                "dataset_name": f"coco_{split}.json",
             }
 
     dataset_infos = {
@@ -236,16 +284,21 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
                     "label_column": None,
                     "labels": class_names,
                 }
-            ]
+            ],
         }
     }
 
     with open(os.path.join(dest_dir, "dataset_infos.json"), "w", encoding="utf-8") as f:
         json.dump(dataset_infos, f, indent=4)
 
+
 def fetch_cli():
-    parser = argparse.ArgumentParser(description="Fetch and format datasets from Roboflow Universe to ModelCat.")
-    parser.add_argument("save_path", help="Local directory to save the ModelCat dataset.")
+    parser = argparse.ArgumentParser(
+        description="Fetch and format datasets from Roboflow Universe to ModelCat."
+    )
+    parser.add_argument(
+        "save_path", help="Local directory to save the ModelCat dataset."
+    )
     parser.add_argument("--url", required=True, help="Roboflow Universe URL")
     args = parser.parse_args()
 
@@ -259,17 +312,19 @@ def fetch_cli():
         sys.exit(1)
 
     api_key = get_api_key()
-    
+
     dest_dir = os.path.abspath(args.save_path)
     if os.path.exists(dest_dir) and os.listdir(dest_dir):
-        log.error(f"Save path '{dest_dir}' already exists and is not empty. Choose an empty directory.")
+        log.error(
+            f"Save path '{dest_dir}' already exists and is not empty. Choose an empty directory."
+        )
         sys.exit(1)
 
     rf = Roboflow(api_key=api_key)
     try:
         workspace = rf.workspace(workspace_name)
         project = workspace.project(project_name)
-        
+
         if version_num is None:
             log.info("No version specified in URL. Scanning for the latest version...")
             try:
@@ -277,31 +332,37 @@ def fetch_cli():
                 version_num = max([int(v.version) for v in versions])
                 log.info(f"Auto-selected latest version: v{version_num}")
             except Exception as e:
-                log.warning(f"Could not auto-detect latest version, defaulting to 1. Details: {e}")
+                log.warning(
+                    f"Could not auto-detect latest version, defaulting to 1. Details: {e}"
+                )
                 version_num = 1
-                
+
         version = project.version(version_num)
-        
+
         rf_type = project.type
         task_mapping = {
             "object-detection": "detection",
             "classification": "classification",
             "single-label-classification": "classification",
             "multi-label-classification": "classification",
-            "keypoint-detection": "keypoints"
+            "keypoint-detection": "keypoints",
         }
-        
+
         if rf_type not in task_mapping:
-            log.error(f"Task type '{rf_type}' is currently unsupported by ModelCat. Supported: detection, classification, keypoints.")
+            log.error(
+                f"Task type '{rf_type}' is currently unsupported by ModelCat. Supported: detection, classification, keypoints."
+            )
             sys.exit(1)
-            
+
         mc_task_type = task_mapping[rf_type]
 
     except Exception as e:
         log.error(f"Failed to fetch project metadata from Roboflow. Details: {e}")
         sys.exit(1)
 
-    log.info(f"Detected task: {mc_task_type}. Fetching {project_name} v{version_num}...")
+    log.info(
+        f"Detected task: {mc_task_type}. Fetching {project_name} v{version_num}..."
+    )
 
     # IMPORTANT: Do NOT use os.makedirs here. If the folder exists, the SDK skips the download!
     tmp_dir = os.path.abspath("./.rf_temp_download")
@@ -312,44 +373,53 @@ def fetch_cli():
         version.download("coco", location=tmp_dir)
         source_data_path = tmp_dir
         log.info(f"Download complete. Extracting from: {source_data_path}")
-        
+
         if mc_task_type == "detection":
             log.info("Cleaning supercategories...")
             clean_supercategories(source_data_path)
-            
+
         rf_license = format_for_modelcat(source_data_path, dest_dir, project_name)
         generate_dataset_infos(dest_dir, project_name, rf_license, mc_task_type)
-        
-        total_images_found = sum([len(files) for r, d, files in os.walk(os.path.join(dest_dir, "images"))])
+
+        total_images_found = sum(
+            [len(files) for r, d, files in os.walk(os.path.join(dest_dir, "images"))]
+        )
         if total_images_found == 0:
-            log.error(f"CRITICAL: The downloaded Roboflow dataset (v{version_num}) contains 0 images.")
-            log.error("PROPOSED FIX: This often happens on Roboflow when a version is generated before images are uploaded.")
-            log.error("Please verify the project on Roboflow Universe and append the correct version to your URL.")
-            shutil.rmtree(dest_dir) 
+            log.error(
+                f"CRITICAL: The downloaded Roboflow dataset (v{version_num}) contains 0 images."
+            )
+            log.error(
+                "PROPOSED FIX: This often happens on Roboflow when a version is generated before images are uploaded."
+            )
+            log.error(
+                "Please verify the project on Roboflow Universe and append the correct version to your URL."
+            )
+            shutil.rmtree(dest_dir)
             sys.exit(1)
-        
+
         thumbnail_path = os.path.join(dest_dir, "thumbnail.jpg")
         if not os.path.exists(thumbnail_path):
             log.info("Generating dataset thumbnail...")
             found_thumbnail = False
             for root, dirs, files in os.walk(os.path.join(dest_dir, "images")):
                 for file in files:
-                    if file.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp')):
+                    if file.lower().endswith((".png", ".jpg", ".jpeg", ".bmp")):
                         shutil.copyfile(os.path.join(root, file), thumbnail_path)
                         found_thumbnail = True
                         break
                 if found_thumbnail:
                     break
-        
+
         log.info(f"Success! Dataset formatted and saved to: {dest_dir}")
         log.info(f"You can now run: modelcat_validate -d {dest_dir}")
-        
+
     except Exception as e:
         log.exception(f"An error occurred during dataset processing: {e}")
         sys.exit(1)
     finally:
         if os.path.exists(tmp_dir):
             shutil.rmtree(tmp_dir)
+
 
 if __name__ == "__main__":
     fetch_cli()

--- a/src/modelcat/connector/fetch.py
+++ b/src/modelcat/connector/fetch.py
@@ -1,0 +1,355 @@
+import argparse
+import json
+import logging as log
+import os
+import re
+import shutil
+import subprocess
+import sys
+from os import environ
+
+# Setup logging
+log.basicConfig(format="%(levelname)s: %(message)s", level=log.INFO)
+
+def ensure_dependencies():
+    """Checks for required dependencies and installs them if missing."""
+    required_packages = {
+        "roboflow": "roboflow",
+        "dotenv": "python-dotenv",
+        "requests": "requests",
+    }
+    missing = [pkg for mod, pkg in required_packages.items() if not __import__('importlib.util').util.find_spec(mod)]
+    if missing:
+        log.info(f"Installing missing dependencies: {', '.join(missing)}...")
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install"] + missing)
+        except subprocess.CalledProcessError as e:
+            log.error(f"Failed to install dependencies: {e}")
+            sys.exit(1)
+
+def parse_roboflow_url(url: str):
+    """Extracts workspace, project, and version from a Roboflow Universe URL."""
+    pattern = r"universe\.roboflow\.com/([^/]+)/([^/]+)(?:/(?:dataset|model)/)?(\d+)?"
+    match = re.search(pattern, url)
+    if not match:
+        raise ValueError("Invalid Roboflow Universe URL. Expected format: https://universe.roboflow.com/<workspace>/<project>[/version]")
+    
+    workspace, project, version = match.groups()
+    return workspace, project, int(version) if version else None
+
+def get_api_key():
+    """Fetches the API key from .env or prompts the user interactively."""
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    api_key = environ.get("ROBOFLOW_API_KEY")
+    if not api_key:
+        print("\nRoboflow API key not found in .env.")
+        print("You can get your API key from https://app.roboflow.com/ -> Settings -> API Keys")
+        api_key = input("Enter your Roboflow API Key: ").strip()
+        if not api_key:
+            log.error("API Key is required to fetch datasets.")
+            sys.exit(1)
+        
+        save = input("Save this key to .env for future use? (y/n): ").strip().lower()
+        if save == 'y':
+            with open(".env", "a") as f:
+                f.write(f"\nROBOFLOW_API_KEY={api_key}\n")
+            log.info("API Key saved to .env")
+    return api_key
+
+def clean_supercategories(base_dir):
+    """Removes supercategories and empty classes."""
+    # Catch both 'valid' and 'val' names
+    splits = ["train", "valid", "val", "test"]
+    anns_by_split = {}
+    for split in splits:
+        p = os.path.join(base_dir, split, "_annotations.coco.json")
+        if os.path.exists(p):
+            with open(p, "r") as f:
+                anns_by_split[split] = json.load(f)
+        else:
+            anns_by_split[split] = None
+
+    all_categories = []
+    for data in anns_by_split.values():
+        if data:
+            all_categories.extend(data.get("categories", []))
+
+    has_supercategories = any(
+        c.get("supercategory", "none") != "none" and c.get("supercategory") is not None
+        for c in all_categories
+    )
+
+    category_counts = {}
+    category_info = {}
+
+    for data in anns_by_split.values():
+        if not data: continue
+        for cat in data.get("categories", []):
+            cat_id = cat["id"]
+            sc = cat.get("supercategory", "none")
+            keep_category = not (has_supercategories and (sc == "none" or sc is None))
+            if keep_category and cat_id not in category_info:
+                category_info[cat_id] = cat
+                category_counts[cat_id] = 0
+
+    for data in anns_by_split.values():
+        if not data: continue
+        for ann in data.get("annotations", []):
+            cat_id = ann["category_id"]
+            if cat_id in category_counts:
+                category_counts[cat_id] += 1
+
+    kept_ids = sorted([cid for cid, count in category_counts.items() if count > 0])
+    id_map = {old_id: new_idx for new_idx, old_id in enumerate(kept_ids)}
+
+    for split, data in anns_by_split.items():
+        if not data: continue
+        new_categories = []
+        for cat in data.get("categories", []):
+            if cat["id"] in id_map:
+                new_cat = cat.copy()
+                new_cat["id"] = id_map[cat["id"]]
+                new_cat["supercategory"] = "none"
+                new_categories.append(new_cat)
+        data["categories"] = sorted(new_categories, key=lambda x: x["id"])
+
+        new_annotations = []
+        for ann in data.get("annotations", []):
+            if ann["category_id"] in id_map:
+                new_ann = ann.copy()
+                new_ann["category_id"] = id_map[ann["category_id"]]
+                new_annotations.append(new_ann)
+        data["annotations"] = new_annotations
+
+        with open(os.path.join(base_dir, split, "_annotations.coco.json"), "w") as f:
+            json.dump(data, f)
+
+def format_for_modelcat(rf_dir, dest_dir, project_name):
+    """Restructures Roboflow export to ModelCat standard."""
+    log.info("Converting dataset to ModelCat format...")
+    os.makedirs(dest_dir, exist_ok=True)
+    os.makedirs(os.path.join(dest_dir, "annotations"), exist_ok=True)
+    os.makedirs(os.path.join(dest_dir, "images"), exist_ok=True)
+
+    # Map all Roboflow variations to ModelCat splits
+    rf_splits = {"train": "train", "valid": "validation", "val": "validation", "test": "test"}
+    rf_license = None
+
+    for rf_split, mc_split in rf_splits.items():
+        src_split_dir = os.path.join(rf_dir, rf_split)
+        if not os.path.exists(src_split_dir):
+            continue
+
+        mc_img_dir = os.path.join(dest_dir, "images", mc_split)
+        if not os.path.exists(mc_img_dir):
+            shutil.copytree(src_split_dir, mc_img_dir, ignore=shutil.ignore_patterns("*.json"))
+
+        ann_path = os.path.join(src_split_dir, "_annotations.coco.json")
+        if os.path.exists(ann_path):
+            with open(ann_path, "r") as f:
+                coco_data = json.load(f)
+            
+            if not rf_license and coco_data.get("licenses"):
+                rf_license = coco_data["licenses"][0]
+
+            for image in coco_data.get("images", []):
+                image["file_name"] = f"{mc_split}/{image['file_name']}"
+            for cat in coco_data.get("categories", []):
+                cat["id"] += 1
+            for annotation in coco_data.get("annotations", []):
+                annotation["category_id"] += 1
+
+            dest_ann_path = os.path.join(dest_dir, "annotations", f"coco_{mc_split}.json")
+            with open(dest_ann_path, "w") as f:
+                json.dump(coco_data, f)
+
+    return rf_license
+
+def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detection"):
+    """Generates the metadata JSON required by ModelCat."""
+    license_name = rf_license.get('name', 'Unknown') if rf_license else 'Unknown'
+    
+    if license_name and any(x in license_name.upper() for x in ["NC", "NON-COMMERCIAL", "GPL"]):
+        log.warning(f"ATTENTION: Dataset has a strictly commercial or restrictive license: {license_name}")
+
+    class_names = []
+    for split in ["train", "validation", "test"]:
+        ann_path = os.path.join(dest_dir, "annotations", f"coco_{split}.json")
+        if os.path.exists(ann_path):
+            with open(ann_path) as f:
+                coco_data = json.load(f)
+                class_names = [c["name"] for c in sorted(coco_data.get("categories", []), key=lambda x: x["id"])]
+                break
+
+    splits = {}
+    total_imgs, total_bytes = 0, 0
+    
+    for split in ["train", "validation", "test"]:
+        img_dir = os.path.join(dest_dir, "images", split)
+        ann_path = os.path.join(dest_dir, "annotations", f"coco_{split}.json")
+        
+        if os.path.exists(img_dir) and os.path.exists(ann_path) and len(os.listdir(img_dir)) > 0:
+            num_imgs = len(os.listdir(img_dir))
+            num_bytes = sum(os.path.getsize(os.path.join(img_dir, f)) for f in os.listdir(img_dir))
+            splits[split] = {
+                "name": split,
+                "num_bytes": num_bytes,
+                "num_examples": num_imgs,
+                "dataset_name": f"coco_{split}.json"
+            }
+            total_imgs += num_imgs
+            total_bytes += num_bytes
+        else:
+            empty_coco = {"info": {}, "licenses": [], "images": [], "annotations": [], "categories": []}
+            os.makedirs(os.path.join(dest_dir, "annotations"), exist_ok=True)
+            os.makedirs(os.path.join(dest_dir, "images", split), exist_ok=True)
+            
+            empty_ann_path = os.path.join(dest_dir, "annotations", f"coco_{split}.json")
+            with open(empty_ann_path, "w") as f:
+                json.dump(empty_coco, f)
+            
+            splits[split] = {
+                "name": split,
+                "num_bytes": 0,
+                "num_examples": 0,
+                "dataset_name": f"coco_{split}.json"
+            }
+
+    dataset_infos = {
+        project_name: {
+            "description": f"Roboflow dataset fetched via modelcat_fetch. License: {license_name}",
+            "license": str(rf_license) if rf_license else "",
+            "builder_name": project_name,
+            "config_name": project_name,
+            "dataset_size": total_imgs,
+            "size_in_bytes": total_bytes,
+            "splits": splits,
+            "task_templates": [
+                {
+                    "task": task_type,
+                    "image_column": "image",
+                    "label_column": None,
+                    "labels": class_names,
+                }
+            ]
+        }
+    }
+
+    with open(os.path.join(dest_dir, "dataset_infos.json"), "w", encoding="utf-8") as f:
+        json.dump(dataset_infos, f, indent=4)
+
+def fetch_cli():
+    parser = argparse.ArgumentParser(description="Fetch and format datasets from Roboflow Universe to ModelCat.")
+    parser.add_argument("save_path", help="Local directory to save the ModelCat dataset.")
+    parser.add_argument("--url", required=True, help="Roboflow Universe URL")
+    args = parser.parse_args()
+
+    ensure_dependencies()
+    from roboflow import Roboflow
+
+    try:
+        workspace_name, project_name, version_num = parse_roboflow_url(args.url)
+    except ValueError as e:
+        log.error(e)
+        sys.exit(1)
+
+    api_key = get_api_key()
+    
+    dest_dir = os.path.abspath(args.save_path)
+    if os.path.exists(dest_dir) and os.listdir(dest_dir):
+        log.error(f"Save path '{dest_dir}' already exists and is not empty. Choose an empty directory.")
+        sys.exit(1)
+
+    rf = Roboflow(api_key=api_key)
+    try:
+        workspace = rf.workspace(workspace_name)
+        project = workspace.project(project_name)
+        
+        if version_num is None:
+            log.info("No version specified in URL. Scanning for the latest version...")
+            try:
+                versions = project.versions()
+                version_num = max([int(v.version) for v in versions])
+                log.info(f"Auto-selected latest version: v{version_num}")
+            except Exception as e:
+                log.warning(f"Could not auto-detect latest version, defaulting to 1. Details: {e}")
+                version_num = 1
+                
+        version = project.version(version_num)
+        
+        rf_type = project.type
+        task_mapping = {
+            "object-detection": "detection",
+            "classification": "classification",
+            "single-label-classification": "classification",
+            "multi-label-classification": "classification",
+            "keypoint-detection": "keypoints"
+        }
+        
+        if rf_type not in task_mapping:
+            log.error(f"Task type '{rf_type}' is currently unsupported by ModelCat. Supported: detection, classification, keypoints.")
+            sys.exit(1)
+            
+        mc_task_type = task_mapping[rf_type]
+
+    except Exception as e:
+        log.error(f"Failed to fetch project metadata from Roboflow. Details: {e}")
+        sys.exit(1)
+
+    log.info(f"Detected task: {mc_task_type}. Fetching {project_name} v{version_num}...")
+
+    # IMPORTANT: Do NOT use os.makedirs here. If the folder exists, the SDK skips the download!
+    tmp_dir = os.path.abspath("./.rf_temp_download")
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)
+
+    try:
+        version.download("coco", location=tmp_dir)
+        source_data_path = tmp_dir
+        log.info(f"Download complete. Extracting from: {source_data_path}")
+        
+        if mc_task_type == "detection":
+            log.info("Cleaning supercategories...")
+            clean_supercategories(source_data_path)
+            
+        rf_license = format_for_modelcat(source_data_path, dest_dir, project_name)
+        generate_dataset_infos(dest_dir, project_name, rf_license, mc_task_type)
+        
+        total_images_found = sum([len(files) for r, d, files in os.walk(os.path.join(dest_dir, "images"))])
+        if total_images_found == 0:
+            log.error(f"CRITICAL: The downloaded Roboflow dataset (v{version_num}) contains 0 images.")
+            log.error("PROPOSED FIX: This often happens on Roboflow when a version is generated before images are uploaded.")
+            log.error("Please verify the project on Roboflow Universe and append the correct version to your URL.")
+            shutil.rmtree(dest_dir) 
+            sys.exit(1)
+        
+        thumbnail_path = os.path.join(dest_dir, "thumbnail.jpg")
+        if not os.path.exists(thumbnail_path):
+            log.info("Generating dataset thumbnail...")
+            found_thumbnail = False
+            for root, dirs, files in os.walk(os.path.join(dest_dir, "images")):
+                for file in files:
+                    if file.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp')):
+                        shutil.copyfile(os.path.join(root, file), thumbnail_path)
+                        found_thumbnail = True
+                        break
+                if found_thumbnail:
+                    break
+        
+        log.info(f"Success! Dataset formatted and saved to: {dest_dir}")
+        log.info(f"You can now run: modelcat_validate -d {dest_dir}")
+        
+    except Exception as e:
+        log.exception(f"An error occurred during dataset processing: {e}")
+        sys.exit(1)
+    finally:
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)
+
+if __name__ == "__main__":
+    fetch_cli()

--- a/src/modelcat/connector/fetch.py
+++ b/src/modelcat/connector/fetch.py
@@ -76,7 +76,6 @@ def get_api_key():
 
 def clean_supercategories(base_dir):
     """Removes supercategories and empty classes."""
-    # Catch both 'valid' and 'val' names
     splits = ["train", "valid", "val", "test"]
     anns_by_split = {}
     for split in splits:
@@ -147,13 +146,12 @@ def clean_supercategories(base_dir):
 
 
 def format_for_modelcat(rf_dir, dest_dir, project_name):
-    """Restructures Roboflow export to ModelCat standard."""
+    """Restructures export to ModelCat standard."""
     log.info("Converting dataset to ModelCat format...")
     os.makedirs(dest_dir, exist_ok=True)
     os.makedirs(os.path.join(dest_dir, "annotations"), exist_ok=True)
     os.makedirs(os.path.join(dest_dir, "images"), exist_ok=True)
 
-    # Map all Roboflow variations to ModelCat splits
     rf_splits = {
         "train": "train",
         "valid": "validation",
@@ -198,7 +196,7 @@ def format_for_modelcat(rf_dir, dest_dir, project_name):
 
 
 def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detection"):
-    """Generates the metadata JSON required by ModelCat."""
+    """Generates the metadata JSON required by ModelCat with dynamic personalized descriptions."""
     license_name = rf_license.get("name", "Unknown") if rf_license else "Unknown"
 
     if license_name and any(
@@ -221,6 +219,28 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
                     )
                 ]
                 break
+
+    # --- NEW: PERSISTENT AND PERSONALIZED DESCRIPTION ENGINE ---
+    # Convert "forklift-bounding-box" into "Forklift Bounding Box"
+    clean_project_name = project_name.replace("-", " ").replace("_", " ").title()
+    clean_task_type = task_type.replace("-", " ").lower()
+
+    # Generate a breakdown of class targets for explicit dataset profiling
+    if class_names:
+        if len(class_names) <= 5:
+            classes_snippet = ", ".join(class_names)
+        else:
+            classes_snippet = ", ".join(class_names[:5]) + f", and {len(class_names) - 5} other unique categories"
+        target_details = f" Dynamically profiles and indexes instances of: {classes_snippet}."
+    else:
+        target_details = ""
+
+    personalized_description = (
+        f"A localized computer vision dataset containing high-fidelity imagery curated for '{clean_project_name}' "
+        f"applications. Structured explicitly for {clean_task_type} tasks.{target_details} "
+        f"Standardized via the ModelCat Fetch Engine. License: {license_name}."
+    )
+    # -----------------------------------------------------------
 
     splits = {}
     total_imgs, total_bytes = 0, 0
@@ -270,7 +290,7 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
 
     dataset_infos = {
         project_name: {
-            "description": f"Roboflow dataset fetched via modelcat_fetch. License: {license_name}",
+            "description": personalized_description, # <--- Injected personalized description string here!
             "license": str(rf_license) if rf_license else "",
             "builder_name": project_name,
             "config_name": project_name,
@@ -294,12 +314,12 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
 
 def fetch_cli():
     parser = argparse.ArgumentParser(
-        description="Fetch and format datasets from Roboflow Universe to ModelCat."
+        description="Fetch and format datasets from source to ModelCat."
     )
     parser.add_argument(
         "save_path", help="Local directory to save the ModelCat dataset."
     )
-    parser.add_argument("--url", required=True, help="Roboflow Universe URL")
+    parser.add_argument("--url", required=True, help="Universe target URL")
     args = parser.parse_args()
 
     ensure_dependencies()
@@ -357,7 +377,7 @@ def fetch_cli():
         mc_task_type = task_mapping[rf_type]
 
     except Exception as e:
-        log.error(f"Failed to fetch project metadata from Roboflow. Details: {e}")
+        log.error(f"Failed to fetch project metadata. Details: {e}")
         sys.exit(1)
 
     log.info(
@@ -386,13 +406,7 @@ def fetch_cli():
         )
         if total_images_found == 0:
             log.error(
-                f"CRITICAL: The downloaded Roboflow dataset (v{version_num}) contains 0 images."
-            )
-            log.error(
-                "PROPOSED FIX: This often happens on Roboflow when a version is generated before images are uploaded."
-            )
-            log.error(
-                "Please verify the project on Roboflow Universe and append the correct version to your URL."
+                f"CRITICAL: The downloaded dataset (v{version_num}) contains 0 images."
             )
             shutil.rmtree(dest_dir)
             sys.exit(1)

--- a/src/modelcat/connector/fetch.py
+++ b/src/modelcat/connector/fetch.py
@@ -230,8 +230,13 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
         if len(class_names) <= 5:
             classes_snippet = ", ".join(class_names)
         else:
-            classes_snippet = ", ".join(class_names[:5]) + f", and {len(class_names) - 5} other unique categories"
-        target_details = f" Dynamically profiles and indexes instances of: {classes_snippet}."
+            classes_snippet = (
+                ", ".join(class_names[:5])
+                + f", and {len(class_names) - 5} other unique categories"
+            )
+        target_details = (
+            f" Dynamically profiles and indexes instances of: {classes_snippet}."
+        )
     else:
         target_details = ""
 
@@ -290,7 +295,7 @@ def generate_dataset_infos(dest_dir, project_name, rf_license, task_type="detect
 
     dataset_infos = {
         project_name: {
-            "description": personalized_description, # <--- Injected personalized description string here!
+            "description": personalized_description,  # <--- Injected personalized description string here!
             "license": str(rf_license) if rf_license else "",
             "builder_name": project_name,
             "config_name": project_name,


### PR DESCRIPTION
Single command CLI utility tool (fetch.py) that doesn't require manual directory prep, automatically creates file structure for you

Uses RegEx to ensure the user's input string is a valid Roboflow Universe URL or raw workspace string, uses provided API Key to initialize the SDK & grabs the specified version and downloads the dataset onto the user's local machine (if no version provided then the module polls the Roboflow API and grabs the latest version released)

Creates a unique, temporary extraction directory (.rf_temp_download) for each execution to avoid an SDK bug (if you create the directory folder before execution, the SDK looks and sees the extraction directory already exists, and thus doesn't edit it and so returns old data)

Transforms the dataset - bounding box & category ID shifting, moves all image folders into one unified images/ directory, and cleans supercategories (as was in the past intern's Confluence page)

Creates the dataset profile (dataset_infos.json) and creates thumbnail image to comply with ModelCat requirements