### PR TITLE
Add tests and validation for empty dataset splits

### DIFF
--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -463,6 +463,8 @@ class DatasetValidator:
                     osp.join(self.ann_dir, ann_file), split_name, label_names
                 )
 
+        messages += self.check_empty_splits(ann_file_names, split_names)
+
         for ann_file in ann_file_names:
             messages += self.check_for_duplicate_images(
                 osp.join(self.ann_dir, ann_file)
@@ -942,6 +944,45 @@ class DatasetValidator:
                     ),
                 }
             )
+        return messages
+
+    def check_empty_splits(
+        self,
+        ann_file_names: List[str],
+        split_names: List[str],
+    ) -> List[Dict[str, str]]:
+        """
+        Validate that no declared split is empty. A split that contains no images
+        cannot be used for training or evaluation, so an empty split is treated as
+        an error.
+
+        Only splits whose annotation file is present and parseable with a valid
+        (but empty) "images" list are flagged here; missing/malformed files and a
+        missing "images" section are reported by validate_coco_file/param_check.
+
+        Returns a list of message dicts (type/message).
+        """
+        messages: List[Dict[str, str]] = []
+        for ann_file, split_name in zip(ann_file_names, split_names):
+            ann_path = osp.join(self.ann_dir, ann_file)
+            try:
+                with open(ann_path, "r") as f:
+                    coco = json.load(f)
+            except Exception:
+                # Missing/malformed COCO file — reported by validate_coco_file/param_check.
+                continue
+
+            images = coco.get("images")
+            if isinstance(images, list) and len(images) == 0:
+                messages.append(
+                    {
+                        "type": "error",
+                        "message": (
+                            f'The "{split_name}" split (annotation file "{ann_file}") is empty: '
+                            f"it contains no images. Every split must contain at least one image."
+                        ),
+                    }
+                )
         return messages
 
     def autofill_img_dim(self, img):

--- a/tests/e2e/fixtures/dataset_mutators.py
+++ b/tests/e2e/fixtures/dataset_mutators.py
@@ -87,6 +87,14 @@ def remove_coco_section(ann_path: str, section: str) -> None:
     save_json(ann_path, data)
 
 
+def empty_split(ann_path: str) -> None:
+    """Empty a split by clearing its images and annotations (categories kept)."""
+    data = load_json(ann_path)
+    data["images"] = []
+    data["annotations"] = []
+    save_json(ann_path, data)
+
+
 def remove_coco_annotation_field(
     ann_path: str, field_name: str, annotation_index: int = 0
 ) -> None:

--- a/tests/e2e/models/dataset_builder.py
+++ b/tests/e2e/models/dataset_builder.py
@@ -131,6 +131,10 @@ class DatasetBuilder:
         mut.corrupt_json(self.ann_file_path(ann_filename))
         return self
 
+    def empty_split(self, ann_filename: str) -> "DatasetBuilder":
+        mut.empty_split(self.ann_file_path(ann_filename))
+        return self
+
     def add_duplicate_image_entry(self, ann_filename: str) -> "DatasetBuilder":
         mut.add_duplicate_image_entry(self.ann_file_path(ann_filename))
         return self

--- a/tests/e2e/tests/test_empty_splits.py
+++ b/tests/e2e/tests/test_empty_splits.py
@@ -1,0 +1,66 @@
+"""
+Empty split validation tests.
+
+A split that contains no images cannot be trained or evaluated on, so any
+empty split (train/validation/test) must be reported as an error and must
+not be signed.
+"""
+import pytest
+
+
+@pytest.mark.e2e
+class TestEmptySplits:
+
+    def test_empty_train_split(self, cli, classification_ds):
+        """An empty train split should produce an error and not pass."""
+        classification_ds.empty_split("coco_train.json")
+        result = cli.validate(classification_ds.path)
+        assert not result.crashed, f"CLI crashed with traceback:\n{result.stderr}"
+        assert result.has_error("empty")
+        assert not result.passed
+
+    def test_empty_test_split(self, cli, classification_ds):
+        """An empty test split should produce an error and not pass."""
+        classification_ds.empty_split("coco_test.json")
+        result = cli.validate(classification_ds.path)
+        assert not result.crashed, f"CLI crashed with traceback:\n{result.stderr}"
+        assert result.has_error("empty")
+        assert not result.passed
+
+    def test_empty_validation_split(self, cli, classification_ds):
+        """An empty validation split should produce an error and not pass."""
+        classification_ds.empty_split("coco_validation.json")
+        result = cli.validate(classification_ds.path)
+        assert not result.crashed, f"CLI crashed with traceback:\n{result.stderr}"
+        assert result.has_error("empty")
+        assert not result.passed
+
+    def test_empty_split_not_silenced_by_autofix(self, cli, classification_ds):
+        """Auto-fix only repairs metadata; an empty split must still error."""
+        classification_ds.empty_split("coco_test.json")
+        result = cli.validate(classification_ds.path, auto_fix=True, auto_fix_2="y")
+        assert result.has_error("empty")
+        assert not result.passed
+
+    def test_empty_split_produces_no_signature(self, cli, classification_ds):
+        """An empty split must not yield a signature hash."""
+        classification_ds.empty_split("coco_validation.json")
+        result = cli.validate(classification_ds.path)
+        assert result.has_error("empty")
+        assert result.signature is None
+
+    def test_empty_split_detection(self, cli, detection_ds):
+        """Empty split errors for object detection datasets too."""
+        detection_ds.empty_split("coco_train.json")
+        result = cli.validate(detection_ds.path)
+        assert not result.crashed, f"CLI crashed with traceback:\n{result.stderr}"
+        assert result.has_error("empty")
+        assert not result.passed
+
+    def test_empty_split_keypoints(self, cli, keypoints_ds):
+        """Empty split errors for keypoints datasets too."""
+        keypoints_ds.empty_split("coco_test.json")
+        result = cli.validate(keypoints_ds.path)
+        assert not result.crashed, f"CLI crashed with traceback:\n{result.stderr}"
+        assert result.has_error("empty")
+        assert not result.passed

--- a/tests/test_empty_splits.py
+++ b/tests/test_empty_splits.py
@@ -1,0 +1,151 @@
+import json
+import os
+import os.path as osp
+import shutil
+import tempfile
+import unittest
+
+from modelcat.connector.validate import DatasetValidator
+from modelcat.connector.utils.misc import _get_dataset_path
+
+
+def _empty_split_file(ann_path: str) -> None:
+    """Clear images and annotations of a COCO split file (keep categories)."""
+    with open(ann_path) as f:
+        coco = json.load(f)
+    coco["images"] = []
+    coco["annotations"] = []
+    with open(ann_path, "w") as f:
+        json.dump(coco, f)
+
+
+def _copy_sample(sample: str, tmp: str) -> str:
+    ds_path = osp.join(_get_dataset_path(), sample)
+    shutil.copytree(ds_path, tmp, dirs_exist_ok=True)
+    return tmp
+
+
+class TestCheckEmptySplitsUnit(unittest.TestCase):
+    """Directly exercise DatasetValidator.check_empty_splits in isolation."""
+
+    ANN_FILES = ["coco_train.json", "coco_validation.json", "coco_test.json"]
+    SPLITS = ["train", "validation", "test"]
+
+    def _make_validator(self, tmp: str) -> DatasetValidator:
+        _copy_sample("classification_sample", tmp)
+        return DatasetValidator(tmp, tmp)
+
+    def test_non_empty_splits_produce_no_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            msgs = dsv.check_empty_splits(self.ANN_FILES, self.SPLITS)
+            self.assertEqual(msgs, [])
+
+    def test_empty_split_produces_single_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            _empty_split_file(osp.join(tmp, "annotations", "coco_test.json"))
+            msgs = dsv.check_empty_splits(self.ANN_FILES, self.SPLITS)
+            self.assertEqual(len(msgs), 1)
+            self.assertEqual(msgs[0]["type"], "error")
+            self.assertIn("empty", msgs[0]["message"].lower())
+            self.assertIn("test", msgs[0]["message"])
+
+    def test_each_split_flagged_when_empty(self):
+        for split_file, split_name in zip(self.ANN_FILES, self.SPLITS):
+            with self.subTest(split=split_name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    dsv = self._make_validator(tmp)
+                    _empty_split_file(osp.join(tmp, "annotations", split_file))
+                    msgs = dsv.check_empty_splits(self.ANN_FILES, self.SPLITS)
+                    errors = [m for m in msgs if m["type"] == "error"]
+                    self.assertEqual(len(errors), 1)
+                    self.assertIn(split_name, errors[0]["message"])
+
+    def test_multiple_empty_splits_each_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            _empty_split_file(osp.join(tmp, "annotations", "coco_test.json"))
+            _empty_split_file(osp.join(tmp, "annotations", "coco_validation.json"))
+            msgs = dsv.check_empty_splits(self.ANN_FILES, self.SPLITS)
+            errors = [m for m in msgs if m["type"] == "error"]
+            self.assertEqual(len(errors), 2)
+
+    def test_missing_file_is_skipped(self):
+        # A missing annotation file is reported by validate_coco_file, not here.
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            os.remove(osp.join(tmp, "annotations", "coco_test.json"))
+            msgs = dsv.check_empty_splits(["coco_test.json"], ["test"])
+            self.assertEqual(msgs, [])
+
+    def test_malformed_file_is_skipped(self):
+        # A malformed annotation file is reported by validate_coco_file, not here.
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            with open(osp.join(tmp, "annotations", "coco_test.json"), "w") as f:
+                f.write("{not valid json")
+            msgs = dsv.check_empty_splits(["coco_test.json"], ["test"])
+            self.assertEqual(msgs, [])
+
+    def test_missing_images_section_is_skipped(self):
+        # A missing "images" section is a param_check error, not an empty-split error.
+        with tempfile.TemporaryDirectory() as tmp:
+            dsv = self._make_validator(tmp)
+            ann_path = osp.join(tmp, "annotations", "coco_test.json")
+            with open(ann_path) as f:
+                coco = json.load(f)
+            del coco["images"]
+            with open(ann_path, "w") as f:
+                json.dump(coco, f)
+            msgs = dsv.check_empty_splits(["coco_test.json"], ["test"])
+            self.assertEqual(msgs, [])
+
+
+class TestEmptySplitsValidateFlow(unittest.TestCase):
+    """Empty splits surface as errors through validate_dataset and block signing."""
+
+    def _validate_with_empty_split(self, sample: str, split_file: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            _copy_sample(sample, tmp)
+            _empty_split_file(osp.join(tmp, "annotations", split_file))
+            dsv = DatasetValidator(tmp, tmp)
+            while True:
+                msgs, restart = dsv.validate_dataset()
+                if not restart:
+                    break
+            # An error must block signing.
+            dsv.create_validation_mark()
+            with open(osp.join(tmp, "dataset_validator_log.txt")) as f:
+                log_text = f.read()
+            return msgs, log_text
+
+    def _assert_empty_error_and_unsigned(self, msgs, log_text):
+        errors = [m for m in msgs if m["type"] == "error"]
+        self.assertTrue(
+            any("empty" in m["message"].lower() for m in errors),
+            f"expected an empty-split error, got: {errors}",
+        )
+        self.assertNotIn("Validation passed and signed", log_text)
+
+    def test_empty_test_split_classification(self):
+        msgs, log_text = self._validate_with_empty_split(
+            "classification_sample", "coco_test.json"
+        )
+        self._assert_empty_error_and_unsigned(msgs, log_text)
+
+    def test_empty_train_split_detection(self):
+        msgs, log_text = self._validate_with_empty_split(
+            "objectdetection_sample", "coco_train.json"
+        )
+        self._assert_empty_error_and_unsigned(msgs, log_text)
+
+    def test_empty_validation_split_keypoints(self):
+        msgs, log_text = self._validate_with_empty_split(
+            "keypoints_sample", "coco_validation.json"
+        )
+        self._assert_empty_error_and_unsigned(msgs, log_text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Added a validation check that prevents users from uploading datasets with empty splits.

Closes https://etacompute.atlassian.net/browse/BOOM-4467