### PR TITLE
Fix O(N^2) validator checks

### DIFF
--- a/src/modelcat/connector/utils/schemas/annotation.py
+++ b/src/modelcat/connector/utils/schemas/annotation.py
@@ -439,7 +439,7 @@ class CocoDataset(BaseModel):
         file_names = [im.file_name for im in images]
         if any((not isinstance(fn, str) or not fn.strip()) for fn in file_names):
             raise ValueError("All images must have a non-empty 'file_name' string.")
-        dupe_fns = [fn for fn in set(file_names) if file_names.count(fn) > 1]
+        dupe_fns = _find_dupes(file_names)
         if dupe_fns:
             raise ValueError(f"Duplicate image file_name(s): {sorted(dupe_fns)}")
 

--- a/src/modelcat/connector/validate.py
+++ b/src/modelcat/connector/validate.py
@@ -526,14 +526,12 @@ class DatasetValidator:
             missing_images = []
             imgs_without_anns = []
 
+            ann_counts = Counter(ann["image_id"] for ann in coco["annotations"])
             for img in coco["images"]:
                 img_path = osp.join(self.image_dir, img["file_name"])
                 if not osp.exists(img_path):
                     missing_images.append(img["file_name"])
-                anns_for_img = [
-                    ann for ann in coco["annotations"] if ann["image_id"] == img["id"]
-                ]
-                if len(anns_for_img) == 0:
+                if ann_counts.get(img["id"], 0) == 0:
                     imgs_without_anns.append(img["file_name"])
 
             if len(missing_images) > 0:
@@ -573,12 +571,11 @@ class DatasetValidator:
                         if image["file_name"] not in imgs_without_anns
                     ]
                     self.reload_coco(coco_file_path, coco)
+                    ann_counts = Counter(ann["image_id"] for ann in coco["annotations"])
                     imgs_without_anns = [
                         img["file_name"]
                         for img in coco["images"]
-                        if not any(
-                            ann["image_id"] == img["id"] for ann in coco["annotations"]
-                        )
+                        if ann_counts.get(img["id"], 0) == 0
                     ]
                     if len(imgs_without_anns) > 0:
                         raise Exception(


### PR DESCRIPTION
Two checks in the connector's dataset validation are quadratic in image count. While it was not observed in small dataset, this was significant on a 1.33M-image dataset (ImageNet-1k) they led to to ~26 h respectively, with no progress output, so the process looks hung. This happens both in Modelcat-connector on the customer end as well as our Dataset Analysis.

Root cause

src/modelcat/connector/validate.py: images-without-annotations check rescans the full annotations list per image:

```
for img in coco["images"]:
    anns_for_img = [
        ann for ann in coco["annotations"] if ann["image_id"] == img["id"]
    ]
```

1.26M images × 1.26M annotations ≈ 1.6×10¹² iterations

src/modelcat/connector/utils/schemas/annotation.py:duplicate-file_name check calls list.count() per unique name inside pydantic validation:

`dupe_fns = [fn for fn in set(file_names) if file_names.count(fn) > 1]`

The O(N) helper _find_dupes() already exists in the same file and is used for every other uniqueness check

Closes: https://etacompute.atlassian.net/browse/BOOM-4681